### PR TITLE
fix(log): avoid panic if no write permission

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -162,10 +162,15 @@ func SetLogger(logDir string, debug, logJSON bool) {
 	var hundler log15.Handler
 	if _, err := os.Stat(logDir); err == nil {
 		logPath := filepath.Join(logDir, "gost.log")
-		hundler = log15.MultiHandler(
-			log15.Must.FileHandler(logPath, logFormat),
-			lvlHundler,
-		)
+		if _, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err != nil {
+			log15.Error("Failed to create a log file", "err", err)
+			hundler = lvlHundler
+		} else {
+			hundler = log15.MultiHandler(
+				log15.Must.FileHandler(logPath, logFormat),
+				lvlHundler,
+			)
+		}
 	} else {
 		hundler = lvlHundler
 	}


### PR DESCRIPTION
```panic: open /var/log/gost/gost.log: permission denied
goroutine 1 [running]:
github.com/inconshreveable/log15.must(...)
        /root/go/pkg/mod/github.com/inconshreveable/log15@v0.0.0-20180818164646-67afb5ed74ec/handler.go:340                                                        
github.com/inconshreveable/log15.muster.FileHandler(0x15f4d60, 0x16, 0x9f9bf0, 0x9394a0, 0x16, 0x0)                                                                
        /root/go/pkg/mod/github.com/inconshreveable/log15@v0.0.0-20180818164646-67afb5ed74ec/handler.go:348 +0x6c                                                  
github.com/knqyf263/gost/util.SetLogger(0x8f7370, 0xd, 0x0)
        /root/go/src/github.com/knqyf263/gost/util/util.go:166 +0x188
github.com/knqyf263/gost/cmd.initConfig()
        /root/go/src/github.com/knqyf263/gost/cmd/root.go:87 +0x120
github.com/spf13/cobra.(*Command).preRun(0xdc15b8)
        /root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:856 +0x40
github.com/spf13/cobra.(*Command).execute(0xdc15b8, 0xe3012c, 0x0, 0x0, 0xdc15b8, 0xe3012c)                                                                        
        /root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:792 +0xd8
github.com/spf13/cobra.(*Command).ExecuteC(0xdc1978, 0x140c148, 0x2, 0x3)
        /root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x238
github.com/spf13/cobra.(*Command).Execute(...)
        /root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
        /root/go/src/github.com/knqyf263/gost/main.go:22 +0xc8
panic: open /var/log/gost/gost.log: permission denied
goroutine 1 [running]:
github.com/inconshreveable/log15.must(...)
        /root/go/pkg/mod/github.com/inconshreveable/log15@v0.0.0-20180818164646-67afb5ed74ec/handler.go:340                                                        
github.com/inconshreveable/log15.muster.FileHandler(0x2df4d60, 0x16, 0x9f9bf0, 0x9394a0, 0x16, 0x0)                                                                
        /root/go/pkg/mod/github.com/inconshreveable/log15@v0.0.0-20180818164646-67afb5ed74ec/handler.go:348 +0x6c                                                  
github.com/knqyf263/gost/util.SetLogger(0x8f7370, 0xd, 0x0)
        /root/go/src/github.com/knqyf263/gost/util/util.go:166 +0x188
github.com/knqyf263/gost/cmd.initConfig()
        /root/go/src/github.com/knqyf263/gost/cmd/root.go:87 +0x120
github.com/spf13/cobra.(*Command).preRun(0xdc10b8)
        /root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:856 +0x40
github.com/spf13/cobra.(*Command).execute(0xdc10b8, 0xe3012c, 0x0, 0x0, 0xdc10b8, 0xe3012c)                                                                        
        /root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:792 +0xd8
github.com/spf13/cobra.(*Command).ExecuteC(0xdc1978, 0x2c0c148, 0x2, 0x3)
        /root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x238
github.com/spf13/cobra.(*Command).Execute(...)
        /root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
        /root/go/src/github.com/knqyf263/gost/main.go:22 +0xc8
```
