### PR TITLE
feat: fix GetMicrosoftMulti nil pointer dereference and add GetDebianMulti, GetUbuntuMulti

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -126,6 +126,12 @@ diff-cveid:
 	@ python integration/diff_server_mode.py cveid --sample_rate 0.01 redhat
 	# @ python integration/diff_server_mode.py cveid --sample_rate 0.01 microsoft
 
+diff-cveids:
+	# @ python integration/diff_server_mode.py cveids --sample_rate 0.01 debian
+	# @ python integration/diff_server_mode.py cveids --sample_rate 0.01 ubuntu
+	@ python integration/diff_server_mode.py cveids --sample_rate 0.01 redhat
+	# @ python integration/diff_server_mode.py cveids --sample_rate 0.01 microsoft
+
 diff-package:
 	@ python integration/diff_server_mode.py package --sample_rate 0.01 debian
 	@ python integration/diff_server_mode.py package --sample_rate 0.01 ubuntu
@@ -135,6 +141,7 @@ diff-server-rdb:
 	integration/gost.old server --dbpath=integration/gost.old.sqlite3 --port 1325 > /dev/null 2>&1 &
 	integration/gost.new server --dbpath=integration/gost.new.sqlite3 --port 1326 > /dev/null 2>&1 &
 	make diff-cveid
+	make diff-cveids
 	make diff-package
 	pkill gost.old 
 	pkill gost.new
@@ -143,6 +150,7 @@ diff-server-redis:
 	integration/gost.old server --dbtype redis --dbpath "redis://127.0.0.1:6379/0" --port 1325 > /dev/null 2>&1 &
 	integration/gost.new server --dbtype redis --dbpath "redis://127.0.0.1:6380/0" --port 1326 > /dev/null 2>&1 &
 	make diff-cveid
+	make diff-cveids
 	make diff-package
 	pkill gost.old 
 	pkill gost.new
@@ -151,5 +159,6 @@ diff-server-rdb-redis:
 	integration/gost.new server --dbpath=integration/gost.new.sqlite3 --port 1325 > /dev/null 2>&1 &
 	integration/gost.new server --dbtype redis --dbpath "redis://127.0.0.1:6380/0" --port 1326 > /dev/null 2>&1 &
 	make diff-cveid
+	make diff-cveids
 	make diff-package
 	pkill gost.new

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -127,8 +127,8 @@ diff-cveid:
 	# @ python integration/diff_server_mode.py cveid --sample_rate 0.01 microsoft
 
 diff-cveids:
-	# @ python integration/diff_server_mode.py cveids --sample_rate 0.01 debian
-	# @ python integration/diff_server_mode.py cveids --sample_rate 0.01 ubuntu
+	@ python integration/diff_server_mode.py cveids --sample_rate 0.01 debian
+	@ python integration/diff_server_mode.py cveids --sample_rate 0.01 ubuntu
 	@ python integration/diff_server_mode.py cveids --sample_rate 0.01 redhat
 	# @ python integration/diff_server_mode.py cveids --sample_rate 0.01 microsoft
 

--- a/db/db.go
+++ b/db/db.go
@@ -24,7 +24,9 @@ type DB interface {
 	GetRedhat(string) *models.RedhatCVE
 	GetRedhatMulti([]string) map[string]models.RedhatCVE
 	GetDebian(string) *models.DebianCVE
+	GetDebianMulti([]string) map[string]models.DebianCVE
 	GetUbuntu(string) *models.UbuntuCVE
+	GetUbuntuMulti([]string) map[string]models.UbuntuCVE
 	GetMicrosoft(string) *models.MicrosoftCVE
 	GetMicrosoftMulti([]string) map[string]models.MicrosoftCVE
 	GetUnfixedCvesRedhat(string, string, bool) map[string]models.RedhatCVE

--- a/db/debian.go
+++ b/db/debian.go
@@ -39,6 +39,18 @@ func (r *RDBDriver) GetDebian(cveID string) *models.DebianCVE {
 	return &c
 }
 
+// GetDebianMulti :
+func (r *RDBDriver) GetDebianMulti(cveIDs []string) map[string]models.DebianCVE {
+	m := map[string]models.DebianCVE{}
+	for _, cveID := range cveIDs {
+		cve := r.GetDebian(cveID)
+		if cve != nil {
+			m[cveID] = *cve
+		}
+	}
+	return m
+}
+
 // InsertDebian :
 func (r *RDBDriver) InsertDebian(cveJSON models.DebianJSON) (err error) {
 	cves := ConvertDebian(cveJSON)

--- a/db/microsoft.go
+++ b/db/microsoft.go
@@ -112,11 +112,11 @@ func (r *RDBDriver) GetMicrosoft(cveID string) *models.MicrosoftCVE {
 // GetMicrosoftMulti :
 func (r *RDBDriver) GetMicrosoftMulti(cveIDs []string) map[string]models.MicrosoftCVE {
 	m := map[string]models.MicrosoftCVE{}
-	if len(cveIDs) == 0 {
-		return m
-	}
 	for _, cveID := range cveIDs {
-		m[cveID] = *r.GetMicrosoft(cveID)
+		mscve := r.GetMicrosoft(cveID)
+		if mscve != nil {
+			m[cveID] = *mscve
+		}
 	}
 	return m
 }

--- a/db/microsoft.go
+++ b/db/microsoft.go
@@ -113,9 +113,9 @@ func (r *RDBDriver) GetMicrosoft(cveID string) *models.MicrosoftCVE {
 func (r *RDBDriver) GetMicrosoftMulti(cveIDs []string) map[string]models.MicrosoftCVE {
 	m := map[string]models.MicrosoftCVE{}
 	for _, cveID := range cveIDs {
-		mscve := r.GetMicrosoft(cveID)
-		if mscve != nil {
-			m[cveID] = *mscve
+		cve := r.GetMicrosoft(cveID)
+		if cve != nil {
+			m[cveID] = *cve
 		}
 	}
 	return m

--- a/db/redhat.go
+++ b/db/redhat.go
@@ -66,9 +66,9 @@ func (r *RDBDriver) GetRedhat(cveID string) *models.RedhatCVE {
 func (r *RDBDriver) GetRedhatMulti(cveIDs []string) map[string]models.RedhatCVE {
 	m := map[string]models.RedhatCVE{}
 	for _, cveID := range cveIDs {
-		rhcve := r.GetRedhat(cveID)
-		if rhcve != nil {
-			m[cveID] = *rhcve
+		cve := r.GetRedhat(cveID)
+		if cve != nil {
+			m[cveID] = *cve
 		}
 	}
 	return m

--- a/db/redhat.go
+++ b/db/redhat.go
@@ -65,9 +65,6 @@ func (r *RDBDriver) GetRedhat(cveID string) *models.RedhatCVE {
 // GetRedhatMulti :
 func (r *RDBDriver) GetRedhatMulti(cveIDs []string) map[string]models.RedhatCVE {
 	m := map[string]models.RedhatCVE{}
-	if len(cveIDs) == 0 {
-		return m
-	}
 	for _, cveID := range cveIDs {
 		rhcve := r.GetRedhat(cveID)
 		if rhcve != nil {

--- a/db/ubuntu.go
+++ b/db/ubuntu.go
@@ -53,6 +53,18 @@ func (r *RDBDriver) GetUbuntu(cveID string) *models.UbuntuCVE {
 	return &c
 }
 
+// GetUbuntuMulti :
+func (r *RDBDriver) GetUbuntuMulti(cveIDs []string) map[string]models.UbuntuCVE {
+	m := map[string]models.UbuntuCVE{}
+	for _, cveID := range cveIDs {
+		cve := r.GetUbuntu(cveID)
+		if cve != nil {
+			m[cveID] = *cve
+		}
+	}
+	return m
+}
+
 // InsertUbuntu :
 func (r *RDBDriver) InsertUbuntu(cveJSONs []models.UbuntuCVEJSON) (err error) {
 	cves := ConvertUbuntu(cveJSONs)

--- a/integration/diff_server_mode.py
+++ b/integration/diff_server_mode.py
@@ -58,6 +58,50 @@ def diff_cveid(args: Tuple[str, str]):
             w.write(json.dumps(response_new, indent=4))
 
 
+def diff_cveids(args: Tuple[str, slice]):
+    session = requests.Session()
+    retries = Retry(total=5,
+                    backoff_factor=1,
+                    status_forcelist=[503, 504])
+    session.mount("http://", HTTPAdapter(max_retries=retries))
+
+    # Endpoint
+    # POST /redhat/multi-cves
+    # POST /microsoft/multi-cves
+    path = f'{args[0]}/multi-cves'
+    k = math.ceil(len(args[1]/5))
+    for _ in range(5):
+        payload = {"cveIDs": random.sample(args[1], k)}
+        try:
+            response_old = session.post(
+                f'http://127.0.0.1:1325/{path}', data=json.dumps(payload), headers={'content-type': 'application/json'}, timeout=2).json()
+            response_new = session.post(
+                f'http://127.0.0.1:1326/{path}', data=json.dumps(payload), headers={'content-type': 'application/json'}, timeout=2).json()
+        except requests.exceptions.ConnectionError as e:
+            logger.error(
+                f'Failed to Connection..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
+            raise
+        except requests.exceptions.ReadTimeout as e:
+            logger.warning(
+                f'Failed to Read Response..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
+            raise
+        except Exception as e:
+            logger.error(
+                f'Failed to GET request..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
+            raise
+
+        diff = DeepDiff(response_old, response_new, ignore_order=True)
+        if diff != {}:
+            logger.warning(
+                f'There is a difference between old and new(or RDB and Redis):\n {pprint.pformat({"mode": "cveid", "args": args, "path": path}, indent=2)}')
+
+            diff_path = f'integration/diff/{args[0]}/cveid/{args[1]}'
+            with open(f'{diff_path}.old', 'w') as w:
+                w.write(json.dumps(response_old, indent=4))
+            with open(f'{diff_path}.new', 'w') as w:
+                w.write(json.dumps(response_new, indent=4))
+
+
 def diff_package(args: Tuple[str, str]):
     session = requests.Session()
     retries = Retry(total=5,
@@ -90,7 +134,8 @@ def diff_package(args: Tuple[str, str]):
     for rel in os_specific_urls[0]:
         for fix_status in os_specific_urls[1]:
             path = f'{args[0]}/{rel}/pkgs/{args[1]}/{fix_status}'
-            os.makedirs(f'integration/diff/{args[0]}/package/{rel}({fix_status})', exist_ok=True)
+            os.makedirs(
+                f'integration/diff/{args[0]}/package/{rel}({fix_status})', exist_ok=True)
             try:
                 response_old = session.get(
                     f'http://127.0.0.1:1325/{path}', timeout=(2.0, 30.0)).json()
@@ -121,18 +166,20 @@ def diff_package(args: Tuple[str, str]):
                     w.write(json.dumps(response_new, indent=4))
 
 
-def diff_response(args: Tuple[str, str, str]):
+def diff_response(args: Tuple[str, str, slice]):
     try:
         if args[0] == 'cveid':
-            diff_cveid((args[1], args[2]))
+            diff_cveid((args[1], args[2][0]))
+        if args[0] == 'cveids':
+            diff_cveids((args[1], args[2]))
         if args[0] == 'package':
-            diff_package((args[1], args[2]))
+            diff_package((args[1], args[2][0]))
     except Exception:
         exit(1)
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('mode', choices=['cveid', 'package'],
+parser.add_argument('mode', choices=['cveid', 'cveids', 'package'],
                     help='Specify the mode to test.')
 parser.add_argument('ostype', choices=['debian', 'ubuntu', 'redhat', 'microsoft'],
                     help='Specify the OS to be started in server mode when testing.')
@@ -178,7 +225,7 @@ list_path = None
 if args.list_path != None:
     list_path = args.list_path
 else:
-    if args.mode == 'cveid':
+    if args.mode in ['cveid', 'cveids']:
         list_path = 'integration/cveid/cveid_' + args.ostype + '.txt'
     if args.mode == 'package':
         list_path = 'integration/package/package_' + args.ostype + '.txt'
@@ -203,6 +250,9 @@ os.makedirs(diff_path, exist_ok=True)
 with open(list_path) as f:
     list = [s.strip() for s in f.readlines()]
     list = random.sample(list, math.ceil(len(list) * args.sample_rate))
-    with ThreadPoolExecutor() as executor:
-        ins = ((args.mode, args.ostype, e) for e in list)
-        executor.map(diff_response, ins)
+    if args.mode == 'cveids':
+        diff_response(args.mode, args.ostype, list)
+    else:
+        with ThreadPoolExecutor() as executor:
+            ins = ((args.mode, args.ostype, [e]) for e in list)
+            executor.map(diff_response, ins)

--- a/server/server.go
+++ b/server/server.go
@@ -42,6 +42,8 @@ func Start(logToFile bool, logDir string, driver db.DB) error {
 	e.GET("/ubuntu/cves/:id", getUbuntuCve(driver))
 	e.GET("/microsoft/cves/:id", getMicrosoftCve(driver))
 	e.POST("/redhat/multi-cves", getRedhatMultiCve(driver))
+	e.POST("/debian/multi-cves", getDebianMultiCve(driver))
+	e.POST("/ubuntu/multi-cves", getUbuntuMultiCve(driver))
 	e.POST("/microsoft/multi-cves", getMicrosoftMultiCve(driver))
 	e.GET("/redhat/:release/pkgs/:name/unfixed-cves", getUnfixedCvesRedhat(driver))
 	e.GET("/debian/:release/pkgs/:name/unfixed-cves", getUnfixedCvesDebian(driver))
@@ -114,6 +116,30 @@ func getRedhatMultiCve(driver db.DB) echo.HandlerFunc {
 			return err
 		}
 		cveDetails := driver.GetRedhatMulti(cveIDs.CveIDs)
+		return c.JSON(http.StatusOK, &cveDetails)
+	}
+}
+
+// Handler
+func getDebianMultiCve(driver db.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		cveIDs := cveIDs{}
+		if err := c.Bind(&cveIDs); err != nil {
+			return err
+		}
+		cveDetails := driver.GetDebianMulti(cveIDs.CveIDs)
+		return c.JSON(http.StatusOK, &cveDetails)
+	}
+}
+
+// Handler
+func getUbuntuMultiCve(driver db.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		cveIDs := cveIDs{}
+		if err := c.Bind(&cveIDs); err != nil {
+			return err
+		}
+		cveDetails := driver.GetUbuntuMulti(cveIDs.CveIDs)
 		return c.JSON(http.StatusOK, &cveDetails)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -41,6 +41,8 @@ func Start(logToFile bool, logDir string, driver db.DB) error {
 	e.GET("/debian/cves/:id", getDebianCve(driver))
 	e.GET("/ubuntu/cves/:id", getUbuntuCve(driver))
 	e.GET("/microsoft/cves/:id", getMicrosoftCve(driver))
+	e.POST("/redhat/multi-cves", getRedhatMultiCve(driver))
+	e.POST("/microsoft/multi-cves", getMicrosoftMultiCve(driver))
 	e.GET("/redhat/:release/pkgs/:name/unfixed-cves", getUnfixedCvesRedhat(driver))
 	e.GET("/debian/:release/pkgs/:name/unfixed-cves", getUnfixedCvesDebian(driver))
 	e.GET("/debian/:release/pkgs/:name/fixed-cves", getFixedCvesDebian(driver))
@@ -97,6 +99,34 @@ func getMicrosoftCve(driver db.DB) echo.HandlerFunc {
 		//TODO error
 		cveDetail := driver.GetMicrosoft(cveid)
 		return c.JSON(http.StatusOK, &cveDetail)
+	}
+}
+
+type cveIDs struct {
+	CveIDs []string `json:"cveIDs"`
+}
+
+// Handler
+func getRedhatMultiCve(driver db.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		cveIDs := cveIDs{}
+		if err := c.Bind(&cveIDs); err != nil {
+			return err
+		}
+		cveDetails := driver.GetRedhatMulti(cveIDs.CveIDs)
+		return c.JSON(http.StatusOK, &cveDetails)
+	}
+}
+
+// Handler
+func getMicrosoftMultiCve(driver db.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		cveIDs := cveIDs{}
+		if err := c.Bind(&cveIDs); err != nil {
+			return err
+		}
+		cveDetails := driver.GetMicrosoftMulti(cveIDs.CveIDs)
+		return c.JSON(http.StatusOK, &cveDetails)
 	}
 }
 


### PR DESCRIPTION
# What did you implement:
If `CVE==nil` in GetMicrosoftMulti in RDB, do not register it.
refs. https://github.com/vulsio/gost/pull/79

Also, GetDebianMulti and GetUbuntuMulti are implemented.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ gost server --dbtype sqlite3 --dbpath ./gost.sqlite3
$ curl -H "Content-type: application/json" -X POST -d '{"cveIDs": []}' http://127.0.0.1:1325/microsoft/multi-cves | jq . // empty CVEIDs
$ curl -H "Content-type: application/json" -X POST -d '{"cveIDs": ["CVE-0000-0000", "CVE-2021-38642"]}' http://127.0.0.1:1325/microsoft/multi-cves | jq . // contains invalid CVEID
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

