### PR TITLE
chore(linter): change linter from golint to revive

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.32
+          version: v1.42
           args: --timeout=10m
           
           # Optional: working directory, useful for monorepos

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ vendor/
 *.sqlite3-journal
 
 *.toml
+!.revive.toml
 
 .vscode
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,44 @@
 name: golang-ci
 
 linters-settings:
-  errcheck:
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    confidence: 0.8
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+  # errcheck:
     #exclude: /path/to/file.txt
 
 linters:
   disable-all: true
   enable:
     - goimports
-    - golint
+    - revive
     - govet
     - misspell
     - errcheck

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,8 +9,8 @@ builds:
   goarch:
   - amd64
   main: .
-  ldflags: -s -w -X main.version={{.Version}} -X main.revision={{.Commit}}
-  binary: go-cve-dictionary
+  ldflags: -s -w -X github.com/vulsio/gost/config.Version={{.Version}} -X github.com/vulsio/gost/config.Revision={{.Commit}}
+  binary: gost
 archives:
 - name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
   format: tar.gz

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,30 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,8 @@
 .PHONY: \
+	all \
 	build \
 	install \
-	all \
-	vendor \
+	lint \
 	vet \
 	fmt \
 	fmtcheck \
@@ -30,16 +30,20 @@ LDFLAGS := -X 'github.com/vulsio/gost/config.Version=$(VERSION)' \
 GO := GO111MODULE=on go
 GO_OFF := GO111MODULE=off go
 
-all: build
+all: build test
 
-build: main.go pretest
+build: main.go
 	$(GO) build -ldflags "$(LDFLAGS)" -o gost  $<
 
-install: main.go pretest
+install: main.go
 	$(GO) install -ldflags "$(LDFLAGS)"
 
-b: 	main.go pretest
+b: 	main.go
 	$(GO) build -ldflags "$(LDFLAGS)" -o gost $<
+
+lint:
+	$(GO_OFF) get -u github.com/mgechev/revive
+	revive -config ./.revive.toml -formatter plain $(PKGS)
 
 vet:
 	echo $(PKGS) | xargs env $(GO) vet || exit;
@@ -53,9 +57,9 @@ mlint:
 fmtcheck:
 	$(foreach file,$(SRCS),gofmt -s -d $(file);)
 
-pretest: vet fmtcheck
+pretest: lint vet fmtcheck
 
-test: 
+test: pretest
 	$(GO) test -cover -v ./... || exit;
 
 unused:

--- a/cmd/debian.go
+++ b/cmd/debian.go
@@ -23,7 +23,7 @@ func init() {
 	fetchCmd.AddCommand(debianCmd)
 }
 
-func fetchDebian(cmd *cobra.Command, args []string) (err error) {
+func fetchDebian(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/cmd/microsoft.go
+++ b/cmd/microsoft.go
@@ -28,7 +28,7 @@ func init() {
 	_ = viper.BindPFlag("apikey", microsoftCmd.PersistentFlags().Lookup("apikey"))
 }
 
-func fetchMicrosoft(cmd *cobra.Command, args []string) (err error) {
+func fetchMicrosoft(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -35,7 +35,7 @@ func init() {
 	_ = viper.BindPFlag("to-slack", RootCmd.PersistentFlags().Lookup("to-slack"))
 }
 
-func executeNotify(cmd *cobra.Command, args []string) (err error) {
+func executeNotify(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/cmd/redhat.go
+++ b/cmd/redhat.go
@@ -23,7 +23,7 @@ func init() {
 	fetchCmd.AddCommand(redHatCmd)
 }
 
-func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
+func fetchRedHat(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/cmd/redhatapi.go
+++ b/cmd/redhatapi.go
@@ -34,7 +34,7 @@ func init() {
 	_ = viper.BindPFlag("list-only", redHatAPICmd.PersistentFlags().Lookup("list-only"))
 }
 
-func fetchRedHatAPI(cmd *cobra.Command, args []string) (err error) {
+func fetchRedHatAPI(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -43,7 +43,7 @@ func init() {
 	_ = viper.BindPFlag("select-after", registerCmd.PersistentFlags().Lookup("select-after"))
 }
 
-func executeRegister(cmd *cobra.Command, args []string) (err error) {
+func executeRegister(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -29,7 +29,7 @@ func init() {
 	_ = viper.BindPFlag("port", serverCmd.PersistentFlags().Lookup("port"))
 }
 
-func executeServer(cmd *cobra.Command, args []string) (err error) {
+func executeServer(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/cmd/ubuntu.go
+++ b/cmd/ubuntu.go
@@ -23,7 +23,7 @@ func init() {
 	fetchCmd.AddCommand(ubuntuCmd)
 }
 
-func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
+func fetchUbuntu(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/db/microsoft.go
+++ b/db/microsoft.go
@@ -12,7 +12,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func (r *RDBDriver) GetCveIDsByMicrosoftKBID(kbID string) ([]string, error) {
+func (r *RDBDriver) GetCveIDsByMicrosoftKBID(_ string) ([]string, error) {
 	// TODO
 	return nil, xerrors.Errorf("GetCveIDsByMicrosoftKBID in RDB is not implemented")
 }
@@ -214,6 +214,6 @@ func (r *RDBDriver) deleteAndInsertMicrosoft(cves []models.MicrosoftCVE) (err er
 }
 
 // GetUnfixedCvesMicrosoft :
-func (r *RDBDriver) GetUnfixedCvesMicrosoft(major, pkgName string, detectWillNotFix ...bool) (map[string]models.MicrosoftCVE, error) {
+func (r *RDBDriver) GetUnfixedCvesMicrosoft(_, _ string, _ ...bool) (map[string]models.MicrosoftCVE, error) {
 	return map[string]models.MicrosoftCVE{}, nil
 }

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -40,7 +40,7 @@ func (r *RDBDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (locked bool, err error) {
+func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, _ Option) (locked bool, err error) {
 	gormConfig := gorm.Config{
 		DisableForeignKeyConstraintWhenMigrating: true,
 		Logger: logger.New(

--- a/db/redis.go
+++ b/db/redis.go
@@ -82,7 +82,7 @@ func (r *RedisDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RedisDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (bool, error) {
+func (r *RedisDriver) OpenDB(_, dbPath string, _ bool, option Option) (bool, error) {
 	return false, r.connectRedis(dbPath, option)
 }
 

--- a/notifier/slack.go
+++ b/notifier/slack.go
@@ -28,10 +28,7 @@ func SendSlack(txt string, conf config.SlackConf) error {
 		IconEmoji: conf.IconEmoji,
 		Channel:   conf.Channel,
 	}
-	if err := send(msg, conf); err != nil {
-		return err
-	}
-	return nil
+	return send(msg, conf)
 }
 
 func send(msg message, conf config.SlackConf) error {

--- a/util/util.go
+++ b/util/util.go
@@ -204,10 +204,7 @@ func FileWalk(root string, targetFiles map[string]struct{}, walkFn func(r io.Rea
 		}
 		defer f.Close()
 
-		if err = walkFn(f, path); err != nil {
-			return err
-		}
-		return nil
+		return walkFn(f, path)
 	})
 	if err != nil {
 		return xerrors.Errorf("error in file walk: %w", err)


### PR DESCRIPTION
# What did you implement:
Change the linter to revive, since golint has been deprecated as follows.
> NOTE: Golint is deprecated and frozen. There's no drop-in replacement for it, but tools such as Staticcheck and go vet should be used instead.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ make lint
$ golangci-lint run -c .golangci.yml
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

