### PR TITLE
fix(db): change fetchmeta insert order

### DIFF
--- a/cmd/debian.go
+++ b/cmd/debian.go
@@ -47,6 +47,11 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	log15.Info("Fetched all CVEs from Debian")
 	cves, err := fetcher.RetrieveDebianCveDetails()
 	if err != nil {
@@ -59,11 +64,6 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 	if err := driver.InsertDebian(cves); err != nil {
 		log15.Error("Failed to insert.", "dbpath",
 			viper.GetString("dbpath"), "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
 		return err
 	}
 

--- a/cmd/microsoft.go
+++ b/cmd/microsoft.go
@@ -52,6 +52,11 @@ func fetchMicrosoft(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
+		return err
+	}
+
 	log15.Info("Fetched all CVEs from Microsoft")
 	apiKey := viper.GetString("apikey")
 	if len(apiKey) == 0 {
@@ -71,11 +76,6 @@ func fetchMicrosoft(cmd *cobra.Command, args []string) (err error) {
 	if err := driver.InsertMicrosoft(cves, xls); err != nil {
 		log15.Error("Failed to insert.", "dbpath",
 			viper.GetString("dbpath"), "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}
 

--- a/cmd/redhat.go
+++ b/cmd/redhat.go
@@ -52,14 +52,14 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
-	log15.Info("Insert RedHat into DB", "db", driver.Name())
-	if err := driver.InsertRedhat(cves); err != nil {
-		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}
 
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
+	log15.Info("Insert RedHat into DB", "db", driver.Name())
+	if err := driver.InsertRedhat(cves); err != nil {
+		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}
 

--- a/cmd/redhatapi.go
+++ b/cmd/redhatapi.go
@@ -58,6 +58,11 @@ func fetchRedHatAPI(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
+		return err
+	}
+
 	log15.Info("Fetch the list of CVEs")
 	entries, err := fetcher.ListAllRedhatCves(
 		viper.GetString("before"), viper.GetString("after"), viper.GetInt("threads"))
@@ -87,11 +92,6 @@ func fetchRedHatAPI(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert RedHat into DB", "db", driver.Name())
 	if err := driver.InsertRedhat(cves); err != nil {
 		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}
 

--- a/cmd/ubuntu.go
+++ b/cmd/ubuntu.go
@@ -52,15 +52,15 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
+		return err
+	}
+
 	log15.Info("Fetched", "CVEs", len(cves))
 	log15.Info("Insert Ubuntu into DB", "db", driver.Name())
 	if err := driver.InsertUbuntu(cves); err != nil {
 		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}
 


### PR DESCRIPTION
# What did you implement:
If an error occurs during the first fetch, it is required to clean the DB during the second Insert. 
The old data can be deleted when updating between the same schema versions.
To avoid this problem, insert FetchMeta first.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

