### PR TITLE
fix(redis): pipe cannot take err except for pipe.Exec

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -561,17 +561,13 @@ func (r *RedisDriver) InsertRedhat(cves []models.RedhatCVE) (err error) {
 				return xerrors.Errorf("Failed to marshal json. err: %w", err)
 			}
 
-			if err := pipe.HSet(ctx, cvekey, cve.Name, string(j)).Err(); err != nil {
-				return xerrors.Errorf("Failed to HSet CVE. err: %w", err)
-			}
+			_ = pipe.HSet(ctx, cvekey, cve.Name, string(j))
 			if _, ok := newDeps[cve.Name]; !ok {
 				newDeps[cve.Name] = map[string]struct{}{}
 			}
 
 			for _, pkg := range cve.PackageState {
-				if err := pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, redhatName, pkg.PackageName), cve.Name).Err(); err != nil {
-					return xerrors.Errorf("Failed to SAdd pkg name. err: %w", err)
-				}
+				_ = pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, redhatName, pkg.PackageName), cve.Name)
 				newDeps[cve.Name][pkg.PackageName] = struct{}{}
 				if _, ok := oldDeps[cve.Name]; ok {
 					delete(oldDeps[cve.Name], pkg.PackageName)
@@ -593,23 +589,17 @@ func (r *RedisDriver) InsertRedhat(cves []models.RedhatCVE) (err error) {
 	pipe := r.conn.Pipeline()
 	for cveID, pkgs := range oldDeps {
 		for pkgName := range pkgs {
-			if err := pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, redhatName, pkgName), cveID).Err(); err != nil {
-				return xerrors.Errorf("Failed to SRem. err: %w", err)
-			}
+			_ = pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, redhatName, pkgName), cveID)
 		}
 		if _, ok := newDeps[cveID]; !ok {
-			if err := pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, redhatName), cveID).Err(); err != nil {
-				return xerrors.Errorf("Failed to HDel. err: %w", err)
-			}
+			_ = pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, redhatName), cveID)
 		}
 	}
 	newDepsJSON, err := json.Marshal(newDeps)
 	if err != nil {
 		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
-	if err := pipe.HSet(ctx, depKey, redhatName, string(newDepsJSON)).Err(); err != nil {
-		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
-	}
+	_ = pipe.HSet(ctx, depKey, redhatName, string(newDepsJSON))
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}
@@ -657,9 +647,7 @@ func (r *RedisDriver) InsertDebian(cves []models.DebianCVE) error {
 			}
 
 			for _, pkg := range cve.Package {
-				if err := pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, debianName, pkg.PackageName), cve.CveID).Err(); err != nil {
-					return xerrors.Errorf("Failed to SAdd pkg name. err: %w", err)
-				}
+				_ = pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, debianName, pkg.PackageName), cve.CveID)
 				newDeps[cve.CveID][pkg.PackageName] = struct{}{}
 				if _, ok := oldDeps[cve.CveID]; ok {
 					delete(oldDeps[cve.CveID], pkg.PackageName)
@@ -681,23 +669,17 @@ func (r *RedisDriver) InsertDebian(cves []models.DebianCVE) error {
 	pipe := r.conn.Pipeline()
 	for cveID, pkgs := range oldDeps {
 		for pkgName := range pkgs {
-			if err := pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, debianName, pkgName), cveID).Err(); err != nil {
-				return xerrors.Errorf("Failed to SRem. err: %w", err)
-			}
+			_ = pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, debianName, pkgName), cveID)
 		}
 		if _, ok := newDeps[cveID]; !ok {
-			if err := pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, debianName), cveID).Err(); err != nil {
-				return xerrors.Errorf("Failed to HDel. err: %w", err)
-			}
+			_ = pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, debianName), cveID)
 		}
 	}
 	newDepsJSON, err := json.Marshal(newDeps)
 	if err != nil {
 		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
-	if err := pipe.HSet(ctx, depKey, debianName, string(newDepsJSON)).Err(); err != nil {
-		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
-	}
+	_ = pipe.HSet(ctx, depKey, debianName, string(newDepsJSON))
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}
@@ -737,17 +719,13 @@ func (r *RedisDriver) InsertUbuntu(cves []models.UbuntuCVE) (err error) {
 				return xerrors.Errorf("Failed to marshal json. err: %w", err)
 			}
 
-			if err := pipe.HSet(ctx, cvekey, cve.Candidate, string(j)).Err(); err != nil {
-				return xerrors.Errorf("Failed to HSet CVE. err: %w", err)
-			}
+			_ = pipe.HSet(ctx, cvekey, cve.Candidate, string(j))
 			if _, ok := newDeps[cve.Candidate]; !ok {
 				newDeps[cve.Candidate] = map[string]struct{}{}
 			}
 
 			for _, pkg := range cve.Patches {
-				if err := pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, ubuntuName, pkg.PackageName), cve.Candidate).Err(); err != nil {
-					return xerrors.Errorf("Failed to SAdd pkg name. err: %w", err)
-				}
+				_ = pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, ubuntuName, pkg.PackageName), cve.Candidate)
 				newDeps[cve.Candidate][pkg.PackageName] = struct{}{}
 				if _, ok := oldDeps[cve.Candidate]; ok {
 					delete(oldDeps[cve.Candidate], pkg.PackageName)
@@ -769,23 +747,17 @@ func (r *RedisDriver) InsertUbuntu(cves []models.UbuntuCVE) (err error) {
 	pipe := r.conn.Pipeline()
 	for cveID, pkgs := range oldDeps {
 		for pkgName := range pkgs {
-			if err := pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, ubuntuName, pkgName), cveID).Err(); err != nil {
-				return xerrors.Errorf("Failed to SRem. err: %w", err)
-			}
+			_ = pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, ubuntuName, pkgName), cveID)
 		}
 		if _, ok := newDeps[cveID]; !ok {
-			if err := pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, ubuntuName), cveID).Err(); err != nil {
-				return xerrors.Errorf("Failed to HDel. err: %w", err)
-			}
+			_ = pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, ubuntuName), cveID)
 		}
 	}
 	newDepsJSON, err := json.Marshal(newDeps)
 	if err != nil {
 		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
-	if err := pipe.HSet(ctx, depKey, ubuntuName, string(newDepsJSON)).Err(); err != nil {
-		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
-	}
+	_ = pipe.HSet(ctx, depKey, ubuntuName, string(newDepsJSON))
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}
@@ -826,9 +798,7 @@ func (r *RedisDriver) InsertMicrosoft(cves []models.MicrosoftCVE, products []mod
 	for idx := range chunkSlice(len(products), batchSize) {
 		pipe := r.conn.Pipeline()
 		for _, p := range products[idx.From:idx.To] {
-			if err := pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, microsoftName, fmt.Sprintf("P#%s", p.ProductID)), p.ProductName).Err(); err != nil {
-				return xerrors.Errorf("Failed to SAdd ProductID. err: %w", err)
-			}
+			_ = pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, microsoftName, fmt.Sprintf("P#%s", p.ProductID)), p.ProductName)
 			if _, ok := newDeps["products"][p.ProductID]; !ok {
 				newDeps["products"][p.ProductID] = map[string]struct{}{}
 			}
@@ -858,17 +828,13 @@ func (r *RedisDriver) InsertMicrosoft(cves []models.MicrosoftCVE, products []mod
 				return xerrors.Errorf("Failed to marshal json. err: %w", err)
 			}
 
-			if err := pipe.HSet(ctx, cvekey, cve.CveID, string(j)).Err(); err != nil {
-				return xerrors.Errorf("Failed to HSet CVE. err: %w", err)
-			}
+			_ = pipe.HSet(ctx, cvekey, cve.CveID, string(j))
 			if _, ok := newDeps["cves"][cve.CveID]; !ok {
 				newDeps["cves"][cve.CveID] = map[string]struct{}{}
 			}
 
 			for _, msKBID := range cve.KBIDs {
-				if err := pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, microsoftName, fmt.Sprintf("K#%s", msKBID.KBID)), cve.CveID).Err(); err != nil {
-					return xerrors.Errorf("Failed to SAdd kbID. err: %w", err)
-				}
+				_ = pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, microsoftName, fmt.Sprintf("K#%s", msKBID.KBID)), cve.CveID)
 				newDeps["cves"][cve.CveID][msKBID.KBID] = struct{}{}
 				if _, ok := oldDeps["cves"][cve.CveID]; ok {
 					delete(oldDeps["cves"][cve.CveID], msKBID.KBID)
@@ -890,30 +856,22 @@ func (r *RedisDriver) InsertMicrosoft(cves []models.MicrosoftCVE, products []mod
 	pipe := r.conn.Pipeline()
 	for productID, productNames := range oldDeps["products"] {
 		for productName := range productNames {
-			if err := pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, microsoftName, fmt.Sprintf("P#%s", productID)), productName).Err(); err != nil {
-				return xerrors.Errorf("Failed to SRem. err: %w", err)
-			}
+			_ = pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, microsoftName, fmt.Sprintf("P#%s", productID)), productName)
 		}
 	}
 	for cveID, kbIDs := range oldDeps["cves"] {
 		for kbID := range kbIDs {
-			if err := pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, microsoftName, fmt.Sprintf("K#%s", kbID)), cveID).Err(); err != nil {
-				return xerrors.Errorf("Failed to SRem. err: %w", err)
-			}
+			_ = pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, microsoftName, fmt.Sprintf("K#%s", kbID)), cveID)
 		}
 		if _, ok := newDeps[cveID]; !ok {
-			if err := pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, microsoftName), cveID).Err(); err != nil {
-				return xerrors.Errorf("Failed to HDel. err: %w", err)
-			}
+			_ = pipe.HDel(ctx, fmt.Sprintf(cveKeyFormat, microsoftName), cveID)
 		}
 	}
 	newDepsJSON, err := json.Marshal(newDeps)
 	if err != nil {
 		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
-	if err := pipe.HSet(ctx, depKey, microsoftName, string(newDepsJSON)).Err(); err != nil {
-		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
-	}
+	_ = pipe.HSet(ctx, depKey, microsoftName, string(newDepsJSON))
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}


### PR DESCRIPTION
# What did you implement:
Since pipe can't get err except for pipe.Exec, I modified the code.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

