### PR TITLE
feat(db): add LastFetchedDate in fetchmeta

### DIFF
--- a/cmd/debian.go
+++ b/cmd/debian.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -28,12 +30,13 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}
 
+	log15.Info("Initialize Database")
 	driver, locked, err := db.NewDB(viper.GetString("dbtype"), viper.GetString("dbpath"), viper.GetBool("debug-sql"), db.Option{})
 	if err != nil {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -41,9 +44,9 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -60,6 +63,11 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert Debian CVEs into DB", "db", driver.Name())
 	if err := driver.InsertDebian(cves); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	return nil

--- a/cmd/debian.go
+++ b/cmd/debian.go
@@ -65,7 +65,7 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/cmd/microsoft.go
+++ b/cmd/microsoft.go
@@ -75,7 +75,7 @@ func fetchMicrosoft(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/cmd/microsoft.go
+++ b/cmd/microsoft.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
@@ -39,7 +40,7 @@ func fetchMicrosoft(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -47,9 +48,9 @@ func fetchMicrosoft(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
@@ -72,6 +73,11 @@ func fetchMicrosoft(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert Microsoft CVEs into DB", "db", driver.Name())
 	if err := driver.InsertMicrosoft(cves, product); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	return nil

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -72,7 +72,7 @@ func notifyRedhat(conf config.Config) error {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -80,7 +80,7 @@ func notifyRedhat(conf config.Config) error {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to notify command. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
 
 	for _, cve := range cves {

--- a/cmd/redhat.go
+++ b/cmd/redhat.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -43,7 +45,7 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -51,9 +53,9 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
@@ -61,6 +63,11 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert RedHat into DB", "db", driver.Name())
 	if err := driver.InsertRedhat(cves); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	return nil

--- a/cmd/redhat.go
+++ b/cmd/redhat.go
@@ -65,7 +65,7 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/cmd/redhatapi.go
+++ b/cmd/redhatapi.go
@@ -94,7 +94,7 @@ func fetchRedHatAPI(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/cmd/redhatapi.go
+++ b/cmd/redhatapi.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
@@ -45,7 +46,7 @@ func fetchRedHatAPI(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -53,9 +54,9 @@ func fetchRedHatAPI(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
@@ -91,6 +92,11 @@ func fetchRedHatAPI(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert RedHat into DB", "db", driver.Name())
 	if err := driver.InsertRedhat(cves); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	return nil

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -78,7 +78,7 @@ func executeRegister(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -86,7 +86,7 @@ func executeRegister(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to register command. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
 
 	log15.Info("Select all RedHat CVEs")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -39,7 +39,7 @@ func executeServer(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -47,7 +47,7 @@ func executeServer(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to start server. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to start server. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
 
 	log15.Info("Starting HTTP Server...")

--- a/cmd/ubuntu.go
+++ b/cmd/ubuntu.go
@@ -63,7 +63,7 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/cmd/ubuntu.go
+++ b/cmd/ubuntu.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -40,7 +42,7 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -48,9 +50,9 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
@@ -59,6 +61,11 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert Ubuntu into DB", "db", driver.Name())
 	if err := driver.InsertUbuntu(cves); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	return nil

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -174,7 +174,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{GostRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion}, nil
+		return &models.FetchMeta{GostRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -174,7 +174,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{GostRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{GostRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/redis.go
+++ b/db/redis.go
@@ -37,26 +37,26 @@ import (
   └───┴──────────────────────────┴──────────────┴─────────────────────────────────────────────┘
 
 - Hash
-  ┌───┬────────────────┬─────────────────┬───────────┬────────────────────────────────────────────────┐
-  │NO │    KEY         │     FIELD       │   VALUE   │                  PURPOSE                       │
-  └───┴────────────────┴─────────────────┴───────────┴────────────────────────────────────────────────┘
-  ┌───┬────────────────┬─────────────────┬───────────┬────────────────────────────────────────────────┐
-  │ 1 │ GOST#RH#CVE    │    $CVEID       │ $CVEJSON  │ (RedHat) TO GET CVEJSON BY CVEID               │
-  ├───┼────────────────┼─────────────────┼───────────┼────────────────────────────────────────────────┤
-  │ 2 │ GOST#DEB#CVE   │    $CVEID       │ $CVEJSON  │ (RedHat) TO GET CVEJSON BY CVEID               │
-  ├───┼────────────────┼─────────────────┼───────────┼────────────────────────────────────────────────┤
-  │ 3 │ GOST#UBU#CVE   │    $CVEID       │ $CVEJSON  │ (RedHat) TO GET CVEJSON BY CVEID               │
-  ├───┼────────────────┼─────────────────┼───────────┼────────────────────────────────────────────────┤
-  │ 4 │ GOST#MS#CVE    │    $CVEID       │ $CVEJSON  │ (RedHat) TO GET CVEJSON BY CVEID               │
-  ├───┼────────────────┼─────────────────┼───────────┼────────────────────────────────────────────────┤
-  │ 5 │ GOST#DEP       │ RH/DEB/UBU/MS   │   JSON    │ TO DELETE OUTDATED AND UNNEEDED KEY AND MEMBER │
-  ├───┼────────────────┼─────────────────┼───────────┼────────────────────────────────────────────────┤
-  │ 6 │ GOST#FETCHMETA │   Revision      │  string   │ GET Gost Binary Revision                       │
-  ├───┼────────────────┼─────────────────┼───────────┼────────────────────────────────────────────────┤
-  │ 7 │ GOST#FETCHMETA │ SchemaVersion   │   uint    │ GET Gost Schema Version                        │
-  ├───┼────────────────┼─────────────────┼───────────┼────────────────────────────────────────────────┤
-  │ 8 │ GOST#FETCHMETA │ LastFetchedDate │ time.Time │ GET Gost Last Fetched Time                     │
-  └───┴────────────────┴─────────────────┴───────────┴────────────────────────────────────────────────┘
+  ┌───┬────────────────┬───────────────┬───────────┬────────────────────────────────────────────────┐
+  │NO │    KEY         │     FIELD     │   VALUE   │                  PURPOSE                       │
+  └───┴────────────────┴───────────────┴───────────┴────────────────────────────────────────────────┘
+  ┌───┬────────────────┬───────────────┬───────────┬────────────────────────────────────────────────┐
+  │ 1 │ GOST#RH#CVE    │    $CVEID     │ $CVEJSON  │ (RedHat) TO GET CVEJSON BY CVEID               │
+  ├───┼────────────────┼───────────────┼───────────┼────────────────────────────────────────────────┤
+  │ 2 │ GOST#DEB#CVE   │    $CVEID     │ $CVEJSON  │ (RedHat) TO GET CVEJSON BY CVEID               │
+  ├───┼────────────────┼───────────────┼───────────┼────────────────────────────────────────────────┤
+  │ 3 │ GOST#UBU#CVE   │    $CVEID     │ $CVEJSON  │ (RedHat) TO GET CVEJSON BY CVEID               │
+  ├───┼────────────────┼───────────────┼───────────┼────────────────────────────────────────────────┤
+  │ 4 │ GOST#MS#CVE    │    $CVEID     │ $CVEJSON  │ (RedHat) TO GET CVEJSON BY CVEID               │
+  ├───┼────────────────┼───────────────┼───────────┼────────────────────────────────────────────────┤
+  │ 5 │ GOST#DEP       │ RH/DEB/UBU/MS │   JSON    │ TO DELETE OUTDATED AND UNNEEDED KEY AND MEMBER │
+  ├───┼────────────────┼───────────────┼───────────┼────────────────────────────────────────────────┤
+  │ 6 │ GOST#FETCHMETA │   Revision    │  string   │ GET Gost Binary Revision                       │
+  ├───┼────────────────┼───────────────┼───────────┼────────────────────────────────────────────────┤
+  │ 7 │ GOST#FETCHMETA │ SchemaVersion │   uint    │ GET Gost Schema Version                        │
+  ├───┼────────────────┼───────────────┼───────────┼────────────────────────────────────────────────┤
+  │ 8 │ GOST#FETCHMETA │ LastFetchedAt │ time.Time │ GET Gost Last Fetched Time                     │
+  └───┴────────────────┴───────────────┴───────────┴────────────────────────────────────────────────┘
 
 **/
 
@@ -144,7 +144,7 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
-		return &models.FetchMeta{GostRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{GostRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	revision, err := r.conn.HGet(ctx, fetchMetaKey, "Revision").Result()
@@ -161,10 +161,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to ParseUint. err: %w", err)
 	}
 
-	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
+	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedAt").Result()
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
-			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedAt. err: %w", err)
 		}
 		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
@@ -173,12 +173,12 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Parse date. err: %w", err)
 	}
 
-	return &models.FetchMeta{GostRevision: revision, SchemaVersion: uint(version), LastFetchedDate: date}, nil
+	return &models.FetchMeta{GostRevision: revision, SchemaVersion: uint(version), LastFetchedAt: date}, nil
 }
 
 // UpsertFetchMeta upsert FetchMeta to Database
 func (r *RedisDriver) UpsertFetchMeta(fetchMeta *models.FetchMeta) error {
-	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedDate": fetchMeta.LastFetchedDate}).Err()
+	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedAt": fetchMeta.LastFetchedAt}).Err()
 }
 
 // GetAfterTimeRedhat :

--- a/db/redis.go
+++ b/db/redis.go
@@ -163,7 +163,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 
 	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		if !errors.Is(err, redis.Nil) {
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		}
+		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
 	date, err := time.Parse(time.RFC3339, datestr)
 	if err != nil {

--- a/models/models.go
+++ b/models/models.go
@@ -1,15 +1,20 @@
 package models
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // LatestSchemaVersion manages the Schema version used in the latest Gost.
 const LatestSchemaVersion = 2
 
 // FetchMeta has meta information about fetched security tracker
 type FetchMeta struct {
-	gorm.Model    `json:"-"`
-	GostRevision  string
-	SchemaVersion uint
+	gorm.Model      `json:"-"`
+	GostRevision    string
+	SchemaVersion   uint
+	LastFetchedDate time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated

--- a/models/models.go
+++ b/models/models.go
@@ -11,10 +11,10 @@ const LatestSchemaVersion = 2
 
 // FetchMeta has meta information about fetched security tracker
 type FetchMeta struct {
-	gorm.Model      `json:"-"`
-	GostRevision    string
-	SchemaVersion   uint
-	LastFetchedDate time.Time
+	gorm.Model    `json:"-"`
+	GostRevision  string
+	SchemaVersion uint
+	LastFetchedAt time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated


### PR DESCRIPTION
# What did you implement:
Add the time when the fetch is completed to fetchmeta.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## RDB
```console
$ gost fetch debian
$ sqlite3 gost.sqlite3  
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 10:02:31.112140894+09:00

$ gost fetch debian
$ sqlite3 gost.sqlite3  
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 10:02:50.617469033+09:00
```

## Redis
```console
$ redis-cli -p 6379
127.0.0.1:6379> HGET GOST#FETCHMETA LastFetchedAt
(nil)

$ gost fetch debian --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET GOST#FETCHMETA LastFetchedAt
"2021-12-26T10:03:23.001829261+09:00"

$ gost fetch debian --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET GOST#FETCHMETA LastFetchedAt
"2021-12-26T10:03:40.80782099+09:00"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
