### PR TITLE
fix(rdb/ubuntu): change to db type: text

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -42,6 +42,7 @@ type DB interface {
 	InsertMicrosoft([]models.MicrosoftCVE, []models.MicrosoftProduct) error
 }
 
+// Option :
 type Option struct {
 	RedisTimeout time.Duration
 }

--- a/models/ubuntu.go
+++ b/models/ubuntu.go
@@ -43,7 +43,7 @@ type UbuntuCVE struct {
 	Notes             []UbuntuNote      `json:"notes"`
 	Bugs              []UbuntuBug       `json:"bugs"`
 	Priority          string            `json:"priority" gorm:"type:varchar(255)"`
-	DiscoveredBy      string            `json:"discovered_by" gorm:"type:varchar(255)"`
+	DiscoveredBy      string            `json:"discovered_by" gorm:"type:text"`
 	AssignedTo        string            `json:"assigned_to" gorm:"type:varchar(255)"`
 	Patches           []UbuntuPatch     `json:"patches"`
 	Upstreams         []UbuntuUpstream  `json:"upstreams"`

--- a/models/ubuntu.go
+++ b/models/ubuntu.go
@@ -33,7 +33,7 @@ type UbuntuPatchJSON struct {
 type UbuntuCVE struct {
 	ID int64 `json:"-"`
 
-	PublicDateAtUSN   time.Time         `json:"public_data_at_usn"`
+	PublicDateAtUSN   time.Time         `json:"public_date_at_usn"`
 	CRD               time.Time         `json:"crd"`
 	Candidate         string            `json:"candidate" gorm:"type:varchar(255);index:idx_ubuntu_cve_candidate"`
 	PublicDate        time.Time         `json:"public_date"`
@@ -107,6 +107,18 @@ func ConvertUbuntu(cveJSONs []UbuntuCVEJSON) (cves []UbuntuCVE) {
 	for _, cve := range cveJSONs {
 		if strings.Contains(cve.Description, "** REJECT **") {
 			continue
+		}
+
+		if cve.PublicDateAtUSN == time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC) {
+			cve.PublicDateAtUSN = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
+		}
+
+		if cve.CRD == time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC) {
+			cve.CRD = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
+		}
+
+		if cve.PublicDate == time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC) {
+			cve.PublicDate = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
 		}
 
 		references := []UbuntuReference{}


### PR DESCRIPTION
# What did you implement:

Fixes #101 

When fetching ubuntu in MySQL and PostgreSQL, an error occurred because it tried to insert a string with a size larger than varchar(255). This has been fixed. Also, when fetching ubuntu with MySQL, some of the dates were `0001-01-01T00:00:00Z`, which caused the insert to fail.

## NOTE
In MySQL and PostgreSQL, you need to change the column type as follows.

### MySQL
```console
$ mysql -pPass@1234 -t gost
mysql: [Warning] Using a password on the command line interface can be insecure.
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 20
Server version: 8.0.27-0ubuntu0.20.04.1 (Ubuntu)

Copyright (c) 2000, 2021, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> ALTER TABLE ubuntu_cves MODIFY COLUMN discovered_by text;
Query OK, 0 rows affected (0.13 sec)

mysql> desc ubuntu_cves;
+--------------------+--------------+------+-----+---------+----------------+
| Field              | Type         | Null | Key | Default | Extra          |
+--------------------+--------------+------+-----+---------+----------------+
| id                 | bigint       | NO   | PRI | NULL    | auto_increment |
| public_date_at_usn | datetime(3)  | YES  |     | NULL    |                |
| crd                | datetime(3)  | YES  |     | NULL    |                |
| candidate          | varchar(255) | YES  | MUL | NULL    |                |
| public_date        | datetime(3)  | YES  |     | NULL    |                |
| description        | text         | YES  |     | NULL    |                |
| ubuntu_description | text         | YES  |     | NULL    |                |
| priority           | varchar(255) | YES  |     | NULL    |                |
| discovered_by      | text         | YES  |     | NULL    |                |
| assigned_to        | varchar(255) | YES  |     | NULL    |                |
+--------------------+--------------+------+-----+---------+----------------+
10 rows in set (0.00 sec)
```

### PostgreSQL
```console
$ psql -d gost
psql (12.9 (Ubuntu 12.9-0ubuntu0.20.04.1))
Type "help" for help.

gost=# ALTER TABLE ubuntu_cves ALTER COLUMN discovered_by TYPE text;
ALTER TABLE
gost=# \d ubuntu_cves
                                           Table "public.ubuntu_cves"
       Column       |           Type           | Collation | Nullable |                 Default                 
--------------------+--------------------------+-----------+----------+-----------------------------------------
 id                 | bigint                   |           | not null | nextval('ubuntu_cves_id_seq'::regclass)
 public_date_at_usn | timestamp with time zone |           |          | 
 crd                | timestamp with time zone |           |          | 
 candidate          | character varying(255)   |           |          | 
 public_date        | timestamp with time zone |           |          | 
 description        | text                     |           |          | 
 ubuntu_description | text                     |           |          | 
 priority           | character varying(255)   |           |          | 
 discovered_by      | text                     |           |          | 
 assigned_to        | character varying(255)   |           |          | 
Indexes:
    "ubuntu_cves_pkey" PRIMARY KEY, btree (id)
    "idx_ubuntu_cve_candidate" btree (candidate)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ gost fetch redhat --dbtype=mysql --dbpath="mainek00n:Pass@1234@tcp(localhost:3306)/gost?parseTime=true"
$ gost fetch debian --dbtype=mysql --dbpath="mainek00n:Pass@1234@tcp(localhost:3306)/gost?parseTime=true"
$ gost fetch ubuntu --dbtype=mysql --dbpath="mainek00n:Pass@1234@tcp(localhost:3306)/gost?parseTime=true"
$ gost fetch microsoft --dbtype=mysql --dbpath="mainek00n:Pass@1234@tcp(localhost:3306)/gost?parseTime=true" --apikey=<API_KEY>

$ gost fetch redhat --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/gost"
$ gost fetch debian --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/gost"
$ gost fetch ubuntu --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/gost"
$ gost fetch microsoft --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/gost" --apikey=<API_KEY>
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
