### PR TITLE
feat(ms): support KB Relation

### DIFF
--- a/cmd/microsoft.go
+++ b/cmd/microsoft.go
@@ -70,8 +70,14 @@ func fetchMicrosoft(_ *cobra.Command, _ []string) (err error) {
 	}
 	cves, product := models.ConvertMicrosoft(cveXMLs, cveXls)
 
+	kbRelationJSON, err := fetcher.RetrieveMicrosoftKBRelation()
+	if err != nil {
+		return xerrors.Errorf("Failed to retrieve Microsoft KB Relation. err: %w", err)
+	}
+	kbRelations := models.ConvertMicrosoftKBRelation(kbRelationJSON)
+
 	log15.Info("Insert Microsoft CVEs into DB", "db", driver.Name())
-	if err := driver.InsertMicrosoft(cves, product); err != nil {
+	if err := driver.InsertMicrosoft(cves, product, kbRelations); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 

--- a/db/db.go
+++ b/db/db.go
@@ -27,7 +27,7 @@ type DB interface {
 	GetDebianMulti([]string) (map[string]models.DebianCVE, error)
 	GetUbuntu(string) (*models.UbuntuCVE, error)
 	GetUbuntuMulti([]string) (map[string]models.UbuntuCVE, error)
-	GetCveIDsByMicrosoftKBID(kbID string) ([]string, error)
+	GetCveIDsByMicrosoftKBID([]string, []string) ([]string, error)
 	GetMicrosoft(string) (*models.MicrosoftCVE, error)
 	GetMicrosoftMulti([]string) (map[string]models.MicrosoftCVE, error)
 	GetUnfixedCvesRedhat(string, string, bool) (map[string]models.RedhatCVE, error)
@@ -39,7 +39,7 @@ type DB interface {
 	InsertRedhat([]models.RedhatCVE) error
 	InsertDebian([]models.DebianCVE) error
 	InsertUbuntu([]models.UbuntuCVE) error
-	InsertMicrosoft([]models.MicrosoftCVE, []models.MicrosoftProduct) error
+	InsertMicrosoft([]models.MicrosoftCVE, []models.MicrosoftProduct, []models.MicrosoftKBRelation) error
 }
 
 // Option :

--- a/db/db.go
+++ b/db/db.go
@@ -27,7 +27,7 @@ type DB interface {
 	GetDebianMulti([]string) (map[string]models.DebianCVE, error)
 	GetUbuntu(string) (*models.UbuntuCVE, error)
 	GetUbuntuMulti([]string) (map[string]models.UbuntuCVE, error)
-	GetCveIDsByMicrosoftKBID([]string, []string) ([]string, error)
+	GetCveIDsByMicrosoftKBID([]string, []string) (map[string][]string, error)
 	GetMicrosoft(string) (*models.MicrosoftCVE, error)
 	GetMicrosoftMulti([]string) (map[string]models.MicrosoftCVE, error)
 	GetUnfixedCvesRedhat(string, string, bool) (map[string]models.RedhatCVE, error)

--- a/db/microsoft.go
+++ b/db/microsoft.go
@@ -8,17 +8,23 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/viper"
 	"github.com/vulsio/gost/models"
+	"github.com/vulsio/gost/util"
 	"golang.org/x/xerrors"
 	"gorm.io/gorm"
 )
 
 // GetCveIDsByMicrosoftKBID :
-func (r *RDBDriver) GetCveIDsByMicrosoftKBID(kbID string) ([]string, error) {
+func (r *RDBDriver) GetCveIDsByMicrosoftKBID(applied []string, unapplied []string) ([]string, error) {
+	kbIDs, err := r.getUnAppliedKBIDs(applied, unapplied)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to get UnApplied KBIDs. err: %w", err)
+	}
+
 	msIDs := []string{}
 	if err := r.conn.
 		Model(&models.MicrosoftKBID{}).
-		Select("microsoft_cve_id").
-		Where("kb_id = ?", kbID).
+		Distinct("microsoft_cve_id").
+		Where("kb_id IN ?", kbIDs).
 		Find(&msIDs).Error; err != nil {
 		return nil, xerrors.Errorf("Failed to get MicrosoftCVEID by KBID. err: %w", err)
 	}
@@ -29,12 +35,60 @@ func (r *RDBDriver) GetCveIDsByMicrosoftKBID(kbID string) ([]string, error) {
 	cveIDs := []string{}
 	if err := r.conn.
 		Model(&models.MicrosoftCVE{}).
-		Select("cve_id").
+		Distinct("cve_id").
 		Where("id IN ?", msIDs).
 		Find(&cveIDs).Error; err != nil {
 		return nil, xerrors.Errorf("Failed to get CVEID by MicrosoftCVEID. err: %w", err)
 	}
 	return cveIDs, nil
+}
+
+func (r *RDBDriver) getUnAppliedKBIDs(applied []string, unapplied []string) ([]string, error) {
+	uniqUnappliedKBIDs := map[string]struct{}{}
+	relations := []models.MicrosoftKBRelation{}
+	if err := r.conn.
+		Preload("SupersededBy").
+		Where("kb_id IN ?", applied).
+		Find(&relations).Error; err != nil {
+		return nil, xerrors.Errorf("Failed to get KB Relation by applied KBID: %q. err: %w", applied, err)
+	}
+
+	for _, relation := range relations {
+		isInApplied := false
+		for _, supersededby := range relation.SupersededBy {
+			if util.StringInSlice(supersededby.KBID, applied) {
+				isInApplied = true
+				break
+			}
+		}
+		if !isInApplied {
+			for _, supersededby := range relation.SupersededBy {
+				uniqUnappliedKBIDs[supersededby.KBID] = struct{}{}
+			}
+		}
+	}
+
+	relations = []models.MicrosoftKBRelation{}
+	if err := r.conn.
+		Preload("SupersededBy").
+		Where("kb_id IN ?", unapplied).
+		Find(&relations).Error; err != nil {
+		return nil, xerrors.Errorf("Failed to get KB Relation by unapplied KBID: %q. err: %w", applied, err)
+	}
+
+	for _, relation := range relations {
+		uniqUnappliedKBIDs[relation.KBID] = struct{}{}
+		for _, supersededby := range relation.SupersededBy {
+			uniqUnappliedKBIDs[supersededby.KBID] = struct{}{}
+		}
+	}
+
+	unappliedKBIDs := []string{}
+	for kbid := range uniqUnappliedKBIDs {
+		unappliedKBIDs = append(unappliedKBIDs, kbid)
+	}
+
+	return unappliedKBIDs, nil
 }
 
 // GetMicrosoft :
@@ -172,9 +226,14 @@ func (r *RDBDriver) GetMicrosoftMulti(cveIDs []string) (map[string]models.Micros
 }
 
 // InsertMicrosoft :
-func (r *RDBDriver) InsertMicrosoft(cves []models.MicrosoftCVE, _ []models.MicrosoftProduct) (err error) {
-	if err = r.deleteAndInsertMicrosoft(cves); err != nil {
+func (r *RDBDriver) InsertMicrosoft(cves []models.MicrosoftCVE, _ []models.MicrosoftProduct, kbRelations []models.MicrosoftKBRelation) error {
+	log15.Info("Inserting cves", "cves", len(cves))
+	if err := r.deleteAndInsertMicrosoft(cves); err != nil {
 		return xerrors.Errorf("Failed to insert Microsoft CVE data. err: %w", err)
+	}
+	log15.Info("Insert KB Relation", "kbRelation", len(kbRelations))
+	if err := r.deleteAndInsertMicrosoftKBRelation(kbRelations); err != nil {
+		return xerrors.Errorf("Failed to insert Microsoft KB Relation data. err: %w", err)
 	}
 	return nil
 }
@@ -230,6 +289,41 @@ func (r *RDBDriver) deleteAndInsertMicrosoft(cves []models.MicrosoftCVE) (err er
 	}
 	bar.Finish()
 
+	return nil
+}
+
+func (r *RDBDriver) deleteAndInsertMicrosoftKBRelation(kbs []models.MicrosoftKBRelation) (err error) {
+	bar := pb.StartNew(len(kbs))
+	tx := r.conn.Begin()
+
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+			return
+		}
+		tx.Commit()
+	}()
+
+	// Delete all old records
+	if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(models.MicrosoftKBRelation{}).Error; err != nil {
+		return xerrors.Errorf("Failed to delete MicrosoftKBRelation. err: %s", err)
+	}
+	if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(models.MicrosoftSupersededBy{}).Error; err != nil {
+		return xerrors.Errorf("Failed to delete MicrosoftSupersededBy. err: %s", err)
+	}
+
+	batchSize := viper.GetInt("batch-size")
+	if batchSize < 1 {
+		return fmt.Errorf("Failed to set batch-size. err: batch-size option is not set properly")
+	}
+
+	for idx := range chunkSlice(len(kbs), batchSize) {
+		if err = tx.Create(kbs[idx.From:idx.To]).Error; err != nil {
+			return xerrors.Errorf("Failed to insert. err: %w", err)
+		}
+		bar.Add(idx.To - idx.From)
+	}
+	bar.Finish()
 	return nil
 }
 

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -136,6 +136,8 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.MicrosoftScoreSet{},
 		&models.MicrosoftProduct{},
 		&models.MicrosoftKBID{},
+		&models.MicrosoftKBRelation{},
+		&models.MicrosoftSupersededBy{},
 	); err != nil {
 		return xerrors.Errorf("Failed to migrate. err: %w", err)
 	}

--- a/fetcher/microsoft.go
+++ b/fetcher/microsoft.go
@@ -1,6 +1,7 @@
 package fetcher
 
 import (
+	"bytes"
 	"encoding/json"
 	"encoding/xml"
 	"regexp"
@@ -10,12 +11,14 @@ import (
 	"github.com/tealeg/xlsx"
 	"github.com/vulsio/gost/models"
 	"github.com/vulsio/gost/util"
+	"golang.org/x/xerrors"
 )
 
 var (
 	updateListURL                   = "https://api.msrc.microsoft.com/Updates?api-version=2016-08-01"
 	bulletinSearchURL               = "https://download.microsoft.com/download/6/7/3/673E4349-1CA5-40B9-8879-095C72D5B49D/BulletinSearch.xlsx"
 	bulletinSearchFrom2001To2008URL = "https://download.microsoft.com/download/6/7/3/673E4349-1CA5-40B9-8879-095C72D5B49D/BulletinSearch2001-2008.xlsx"
+	kbRelationURL                   = "https://raw.githubusercontent.com/MaineK00n/ms-kb-relation/main/ms_kb.json"
 	msDateRegexp                    = regexp.MustCompile(`\d+[-\/]\d+[-\/]\d+`)
 )
 
@@ -89,4 +92,17 @@ func XlsToModel(bs []byte) (cves []models.MicrosoftBulletinSearch, err error) {
 		}
 	}
 	return cves, nil
+}
+
+// RetrieveMicrosoftKBRelation :
+func RetrieveMicrosoftKBRelation() (map[string][]string, error) {
+	res, err := util.FetchURL(kbRelationURL, "")
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to fetch KB Relation JSON. err: %w", err)
+	}
+	var kbRelation map[string][]string
+	if err := json.NewDecoder(bytes.NewReader(res)).Decode(&kbRelation); err != nil {
+		return nil, xerrors.Errorf("Failed to decode KB Relation. err: %w", err)
+	}
+	return kbRelation, nil
 }

--- a/models/microsoft.go
+++ b/models/microsoft.go
@@ -326,6 +326,20 @@ type MicrosoftProduct struct {
 	ProductName    string `json:"product_name" gorm:"type:varchar(255)"`
 }
 
+// MicrosoftKBRelation :
+type MicrosoftKBRelation struct {
+	ID           int64  `json:"-"`
+	KBID         string `json:"kbid" gorm:"type:varchar(255);index:idx_microsoft_relation_kb_id"`
+	SupersededBy []MicrosoftSupersededBy
+}
+
+// MicrosoftSupersededBy :
+type MicrosoftSupersededBy struct {
+	ID                    int64  `json:"-"`
+	MicrosoftKBRelationID int64  `json:"-" gorm:"index:idx_microsoft_superseded_by_microsoft_kb_relation_id"`
+	KBID                  string `json:"kbid" gorm:"type:varchar(255);index:idx_microsoft_superseded_by_kb_id"`
+}
+
 // ConvertMicrosoft :
 func ConvertMicrosoft(cveXMLs []MicrosoftXML, cveXls []MicrosoftBulletinSearch) (cves []MicrosoftCVE, msProducts []MicrosoftProduct) {
 	uniqCve := map[string]MicrosoftCVE{}
@@ -769,4 +783,23 @@ func getProductFromName(msProducts []MicrosoftProduct, productName string) Micro
 	return MicrosoftProduct{
 		ProductName: productName,
 	}
+}
+
+func ConvertMicrosoftKBRelation(kbRelationJSON map[string][]string) []MicrosoftKBRelation {
+	kbRelations := []MicrosoftKBRelation{}
+
+	for kbid, supersededbyKBIDs := range kbRelationJSON {
+		supersededby := []MicrosoftSupersededBy{}
+		for _, kbid := range supersededbyKBIDs {
+			supersededby = append(supersededby, MicrosoftSupersededBy{
+				KBID: kbid,
+			})
+		}
+		kbRelations = append(kbRelations, MicrosoftKBRelation{
+			KBID:         kbid,
+			SupersededBy: supersededby,
+		})
+	}
+
+	return kbRelations
 }

--- a/models/microsoft.go
+++ b/models/microsoft.go
@@ -785,6 +785,7 @@ func getProductFromName(msProducts []MicrosoftProduct, productName string) Micro
 	}
 }
 
+// ConvertMicrosoftKBRelation :
 func ConvertMicrosoftKBRelation(kbRelationJSON map[string][]string) []MicrosoftKBRelation {
 	kbRelations := []MicrosoftKBRelation{}
 


### PR DESCRIPTION
# What did you implement:
Change the search method from using only unapplied KBIDs to using both applied KBIDs and unapplied KBIDs.
This change will allow us to detect CVE-IDs that may exist between applied and unapplied KBIDs by considering the supersededby of each KBID.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ curl -H "Content-type: application/json" -X POST -d '{"applied": ["2079403"], "unapplied": ["2092914"]}' http://127.0.0.1:1325/microsoft/kbids | jq .
{
  "2092914": [
    "CVE-2010-1903",
    "CVE-2010-1900",
    "CVE-2010-1902",
    "CVE-2010-1901"
  ],
  "2431831": [
    "CVE-2010-3946",
    "CVE-2010-3947",
    "CVE-2010-3952",
    "CVE-2010-3949",
    "CVE-2010-3951",
    "CVE-2010-3950",
    "CVE-2010-3945"
  ],
  "2680317": [
    "CVE-2012-0177"
  ],
  "2719985": [
    "CVE-2012-1889"
  ],
  "2754670": [
    "CVE-2012-2550"
  ],
  "2757638": [
    "CVE-2013-0007",
    "CVE-2013-0006"
  ]
}
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

