### PR TITLE
fix(microsoft): consider CVE-ID fixed in applied

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.12.0
 	github.com/tealeg/xlsx v1.0.5
+	golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd
 	golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gorm.io/driver/mysql v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd h1:zVFyTKZN/Q7mNRWSs1GOYnHM9NiFSJ54YVRsD0rNWT4=
+golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/util/util.go
+++ b/util/util.go
@@ -233,16 +233,6 @@ func Exists(path string) (bool, error) {
 	return true, err
 }
 
-// StringInSlice search within Slice by String
-func StringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
-
 // Exec run the command
 func Exec(command string, args []string) (string, error) {
 	cmd := exec.Command(command, args...)


### PR DESCRIPTION
# What did you implement:

The following URL is the MSRC's vulnerability information page for CVE-2021-28317.
https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-28317

It appears that Windows Server 2012 R2 will be fixed by applying either Monthly Rollup: 5001382 or Security Only: 5001393.
Currently, when unapplied and applied KBIDs were included respectively (e.g. unapplied: 5001382, applied: 5001393), the CVE-ID was false positive.
This PR fixes this bug.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ curl -H "Content-type: application/json" -X POST -d '{"applied": ["5001393"], "unapplied": ["5001382"]}' http://127.0.0.1:1325/microsoft/kbids | jq . | grep "CVE-2021-28317"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5532    0  5482  100    50  60911    555 --:--:-- --:--:-- --:--:-- 61466
    "CVE-2021-28317",
```

## after
```console
$ curl -H "Content-type: application/json" -X POST -d '{"applied": ["5001393"], "unapplied": ["5001382"]}' http://127.0.0.1:1325/microsoft/kbids | jq . | grep "CVE-2021-28317"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4585    0  4535  100    50  50388    555 --:--:-- --:--:-- --:--:-- 50944
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

