### PR TITLE
refactor(db): specify fixed status to be detected unfixed vulnerables

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -32,7 +32,7 @@ type DB interface {
 	GetUbuntu(string) (*models.UbuntuCVE, error)
 	GetUbuntuMulti([]string) (map[string]models.UbuntuCVE, error)
 	GetFixedCvesUbuntu(string, string) (map[string]models.UbuntuCVE, error)
-	GetUnfixedCvesUbuntu(string, string) (map[string]models.UbuntuCVE, error)
+	GetUnfixedCvesUbuntu(string, string, bool) (map[string]models.UbuntuCVE, error)
 	GetMicrosoft(string) (*models.MicrosoftCVE, error)
 	GetMicrosoftMulti([]string) (map[string]models.MicrosoftCVE, error)
 	GetExpandKB([]string, []string) ([]string, []string, error)

--- a/db/db.go
+++ b/db/db.go
@@ -28,7 +28,7 @@ type DB interface {
 	GetDebian(string) (*models.DebianCVE, error)
 	GetDebianMulti([]string) (map[string]models.DebianCVE, error)
 	GetFixedCvesDebian(string, string) (map[string]models.DebianCVE, error)
-	GetUnfixedCvesDebian(string, string) (map[string]models.DebianCVE, error)
+	GetUnfixedCvesDebian(string, string, bool) (map[string]models.DebianCVE, error)
 	GetUbuntu(string) (*models.UbuntuCVE, error)
 	GetUbuntuMulti([]string) (map[string]models.UbuntuCVE, error)
 	GetFixedCvesUbuntu(string, string) (map[string]models.UbuntuCVE, error)

--- a/db/redis.go
+++ b/db/redis.go
@@ -411,12 +411,16 @@ func (r *RedisDriver) GetDebianMulti(cveIDs []string) (map[string]models.DebianC
 	return results, nil
 }
 
-// GetUnfixedCvesUbuntu :
-func (r *RedisDriver) GetUnfixedCvesUbuntu(major, pkgName string) (map[string]models.UbuntuCVE, error) {
-	return r.getCvesUbuntuWithFixStatus(major, pkgName, []string{"needed", "deferred", "pending"})
+// GetUnfixedCvesUbuntu gets the CVEs related to ubuntu_release_patches.status IN ('needed', 'deferred', 'pending', 'active', 'ignored'), ver, pkgName.
+func (r *RedisDriver) GetUnfixedCvesUbuntu(major, pkgName string, strict bool) (map[string]models.UbuntuCVE, error) {
+	states := []string{"needed", "deferred", "pending", "active"}
+	if !strict {
+		states = append(states, "ignored")
+	}
+	return r.getCvesUbuntuWithFixStatus(major, pkgName, states)
 }
 
-// GetFixedCvesUbuntu :
+// GetFixedCvesUbuntu gets the CVEs related to ubuntu_release_patches.status IN ('released'), ver, pkgName.
 func (r *RedisDriver) GetFixedCvesUbuntu(major, pkgName string) (map[string]models.UbuntuCVE, error) {
 	return r.getCvesUbuntuWithFixStatus(major, pkgName, []string{"released"})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -235,7 +235,7 @@ func getUnfixedCvesUbuntu(driver db.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		release := util.Major(c.Param("release"))
 		pkgName := c.Param("name")
-		cveDetail, err := driver.GetUnfixedCvesUbuntu(release, pkgName)
+		cveDetail, err := driver.GetUnfixedCvesUbuntu(release, pkgName, false)
 		if err != nil {
 			log15.Error("Failed to get Unfixed CVEs in Ubuntu", "err", err)
 			return err

--- a/server/server.go
+++ b/server/server.go
@@ -207,7 +207,7 @@ func getUnfixedCvesDebian(driver db.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		release := util.Major(c.Param("release"))
 		pkgName := c.Param("name")
-		cveDetail, err := driver.GetUnfixedCvesDebian(release, pkgName)
+		cveDetail, err := driver.GetUnfixedCvesDebian(release, pkgName, false)
 		if err != nil {
 			log15.Error("Failed to get Unfixed CVEs in Debian", "err", err)
 			return err


### PR DESCRIPTION
# What did you implement:
This PR attempts to clarify the fixed status that should be detected as fixed/unfixed vulnerabilities.

## RedHat
- Affected: this package is affected by this flaw on this platform
- Not affected: this package, which ships on this platform, is not affected by this flaw
- Fix deferred: this package is affected by this flaw on this platform, and may be fixed in the future
- Under investigation: it is currently unknown whether or not this flaw affects this package on this platform, and it is under investigation
- Will not fix: this package is affected by this flaw on this platform, but there is currently no intention to fix it (this would primarily be for flaws that are of Low or Moderate impact that pose no significant risk to customers)
- Out of support scope: When a product is listed as "Out of Support Scope", it means a vulnerability with the impact level assigned to this CVE is no longer covered by its current [support lifecycle phase](https://access.redhat.com/product-life-cycles/update_policies). The product has been identified to contain the impacted component, but analysis to determine whether it is affected or not by this vulnerability was not performed. The product should be assumed to be affected. Customers are advised to apply any mitigation options documented on this page, consider removing or disabling the impacted component, or upgrade to a supported version of the product that has an update available.
- New: 

Previously, `Under investigation` was also a target of detection, but as explained, it is not known whether it is affected or not, so it is excluded from the detection.

## Debian:
- open:unfixed
- resolved:fixed
- undetermined: Packages that may be vulnerable but need to be checked

## Ubuntu:
- DNE: The package (for the given release) does not exist in the archive.
- deferred: The package (for the given release) is vulnerable, the problem is understood, but has been deferred for some reason.
- ignored: This package (for the given release), while related to the CVE in some way, is being ignored for some reason. This could be because the package is no longer supported, or the CVE has been withdrawn, or because fixing the issue would break other functionality.
- needed: This package (for the given release) is vulnerable to the CVE and needs fixing.  (Notes are valid.)
- needs-triage: The vulnerability of this package (for the given release) is not known.  It needs to be evaluated.  (No version/notes)
- not-affected: This package (for the given release), while related to the CVE in some way, is not affected by the issue.
- pending: This package (for the given release) is vulnerable, and an update is pending, usually waiting for upload or publication. 
- released: The package (for the given release) was vulnerable, but an update has been uploaded and published.
- active: The package (for the given release) is vulnerable to the CVE, needs fixing, and is actively being worked on by the person belonging to the IRC nick in the "Assigned-to" field. (Notes are valid.)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

