### PR TITLE
feat(ubuntu): support Ubuntu ESM

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -440,19 +440,8 @@ func (r *RedisDriver) getCvesUbuntuWithFixStatus(major, pkgName string, fixStatu
 			}
 			relPatches := []models.UbuntuReleasePatch{}
 			for _, relPatch := range p.ReleasePatches {
-				found := false
-				for _, codeName := range esmCodeNames {
-					if relPatch.ReleaseName == codeName {
-						found = true
-					}
-				}
-				if !found {
-					continue
-				}
-				for _, s := range fixStatus {
-					if s == relPatch.Status {
-						relPatches = append(relPatches, relPatch)
-					}
+				if slices.Contains(esmCodeNames, relPatch.ReleaseName) && slices.Contains(fixStatus, relPatch.Status) {
+					relPatches = append(relPatches, relPatch)
 				}
 			}
 			if len(relPatches) == 0 {

--- a/db/redis.go
+++ b/db/redis.go
@@ -413,6 +413,13 @@ func (r *RedisDriver) getCvesUbuntuWithFixStatus(major, pkgName string, fixStatu
 	if !ok {
 		return nil, xerrors.Errorf("Failed to convert from major version to codename. err: Ubuntu %s is not supported yet", major)
 	}
+	esmCodeNames := []string{
+		codeName,
+		fmt.Sprintf("esm-apps/%s", codeName),
+		fmt.Sprintf("esm-infra/%s", codeName),
+		fmt.Sprintf("%s/esm", codeName),
+		fmt.Sprintf("ros-esm/%s", codeName),
+	}
 
 	ctx := context.Background()
 	cveIDs, err := r.conn.SMembers(ctx, fmt.Sprintf(pkgKeyFormat, ubuntuName, pkgName)).Result()
@@ -433,11 +440,18 @@ func (r *RedisDriver) getCvesUbuntuWithFixStatus(major, pkgName string, fixStatu
 			}
 			relPatches := []models.UbuntuReleasePatch{}
 			for _, relPatch := range p.ReleasePatches {
-				if relPatch.ReleaseName == codeName {
-					for _, s := range fixStatus {
-						if s == relPatch.Status {
-							relPatches = append(relPatches, relPatch)
-						}
+				found := false
+				for _, codeName := range esmCodeNames {
+					if relPatch.ReleaseName == codeName {
+						found = true
+					}
+				}
+				if !found {
+					continue
+				}
+				for _, s := range fixStatus {
+					if s == relPatch.Status {
+						relPatches = append(relPatches, relPatch)
 					}
 				}
 			}

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,6 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/glebarez/go-sqlite v1.21.1 h1:7MZyUPh2XTrHS7xNEHQbrhfMZuPSzhkm2A1qgg0y5NY=
 github.com/glebarez/go-sqlite v1.21.1/go.mod h1:ISs8MF6yk5cL4n/43rSOmVMGJJjHYr7L2MbZZ5Q4E2E=
-github.com/glebarez/sqlite v1.8.0 h1:02X12E2I/4C1n+v90yTqrjRa8yuo7c3KeHI3FRznCvc=
-github.com/glebarez/sqlite v1.8.0/go.mod h1:bpET16h1za2KOOMb8+jCp6UBP/iahDpfPQqSaYLTLx8=
 github.com/glebarez/sqlite v1.8.1-0.20230417114740-1accfe103bf2 h1:8eKywNub+ODJFAX09rR1expYi1txo5YuC2CzOO4Ukg8=
 github.com/glebarez/sqlite v1.8.1-0.20230417114740-1accfe103bf2/go.mod h1:bi4HJkWd11eriAoPVOutDJcEGV0vk4+pB7+wJ7k3Z4o=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
@@ -663,16 +661,12 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-modernc.org/libc v1.22.3 h1:D/g6O5ftAfavceqlLOFwaZuA5KYafKwmr30A6iSqoyY=
-modernc.org/libc v1.22.3/go.mod h1:MQrloYP209xa2zHome2a8HLiLm6k0UT8CoHpV74tOFw=
 modernc.org/libc v1.22.5 h1:91BNch/e5B0uPbJFgqbxXuOnxBQjlS//icfQEGmvyjE=
 modernc.org/libc v1.22.5/go.mod h1:jj+Z7dTNX8fBScMVNRAYZ/jF91K8fdT2hYMThc3YjBY=
 modernc.org/mathutil v1.5.0 h1:rV0Ko/6SfM+8G+yKiyI830l3Wuz1zRutdslNoQ0kfiQ=
 modernc.org/mathutil v1.5.0/go.mod h1:mZW8CKdRPY1v87qxC/wUdX5O1qDzXMP5TH3wjfpga6E=
 modernc.org/memory v1.5.0 h1:N+/8c5rE6EqugZwHii4IFsaJ7MUhoWX07J5tC/iI5Ds=
 modernc.org/memory v1.5.0/go.mod h1:PkUhL0Mugw21sHPeskwZW4D6VscE/GQJOnIpCnW6pSU=
-modernc.org/sqlite v1.21.1 h1:GyDFqNnESLOhwwDRaHGdp2jKLDzpyT/rNLglX3ZkMSU=
-modernc.org/sqlite v1.21.1/go.mod h1:XwQ0wZPIh1iKb5mkvCJ3szzbhk+tykC8ZWqTRTgYRwI=
 modernc.org/sqlite v1.22.0 h1:Uo+wEWePCspy4SAu0w2VbzUHEftOs7yoaWX/cYjsq84=
 modernc.org/sqlite v1.22.0/go.mod h1:cxbLkB5WS32DnQqeH4h4o1B0eMr8W/y8/RGuxQ3JsC0=
 moul.io/http2curl v1.0.0 h1:6XwpyZOYsgZJrU8exnG87ncVkU1FVCcTRpwzOkTDUi8=


### PR DESCRIPTION
# What did you implement:

The Ubuntu Security Tracker includes data for Ubuntu ESM. 
This update enables Vuls to scan Ubuntu Linux versions even after their End of Life (EOL). 
Information pertaining to Ubuntu ESM is available in a specific format; by incorporating this data into our search parameters, we can detect Vulns of Ubuntu ESM.

https://ubuntu.com/security/esm

```
sqlite> select distinct release_name from ubuntu_release_patches where release_name like '%esm%' limit 1000;
esm-apps/bionic
esm-apps/focal
esm-apps/jammy
esm-apps/xenial
esm-infra/xenial
precise/esm
ros-esm/bionic
ros-esm/xenial
trusty/esm
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
./gost.new version     gost v0.4.3 6886bb9
./gost.old version       gost v0.4.3 8dc024f
```

make diff-server-rdb-redis
```
make diff-server-rdb-redis                                                                                                                       ✔
integration/gost.new server --dbpath=integration/gost.new.sqlite3 --port 1325 > /dev/null 2>&1 &
integration/gost.new server --dbtype redis --dbpath "redis://127.0.0.1:6380/0" --port 1326 > /dev/null 2>&1 &
make diff-cveid
make[1]: ディレクトリ '/home/kota/go/src/github.com/vulsio/gost' に入ります
#@ python integration/diff_server_mode.py cveid --sample_rate 0.01 debian
INFO[05-23|04:04:02] start ubuntu server mode test(mode: cveid)
INFO[05-23|04:04:02] check the communication with the server
INFO[05-23|04:04:02] communication with the server has been confirmed
#@ python integration/diff_server_mode.py cveid --sample_rate 0.01 redhat
# @ python integration/diff_server_mode.py cveid --sample_rate 0.01 microsoft
make[1]: ディレクトリ '/home/kota/go/src/github.com/vulsio/gost' から出ます
make diff-cveids
make[1]: ディレクトリ '/home/kota/go/src/github.com/vulsio/gost' に入ります
#@ python integration/diff_server_mode.py cveids --sample_rate 0.01 debian
INFO[05-23|04:04:04] start ubuntu server mode test(mode: cveids)
INFO[05-23|04:04:04] check the communication with the server
INFO[05-23|04:04:04] communication with the server has been confirmed
#@ python integration/diff_server_mode.py cveids --sample_rate 0.01 redhat
# @ python integration/diff_server_mode.py cveids --sample_rate 0.01 microsoft
make[1]: ディレクトリ '/home/kota/go/src/github.com/vulsio/gost' から出ます
make diff-package
make[1]: ディレクトリ '/home/kota/go/src/github.com/vulsio/gost' に入ります
#@ python integration/diff_server_mode.py package --sample_rate 0.01 debian
INFO[05-23|04:04:06] start ubuntu server mode test(mode: package)
INFO[05-23|04:04:06] check the communication with the server
INFO[05-23|04:04:06] communication with the server has been confirmed
#@ python integration/diff_server_mode.py package --sample_rate 0.01 redhat
# @ python integration/diff_server_mode.py kbid --sample_rate 0.01 microsoft
make[1]: ディレクトリ '/home/kota/go/src/github.com/vulsio/gost' から出ます
pkill gost.new
```


I will paste a part of the comparison between rdb.new and rdb.old. It has become possible to detect new cases of ESM that had not been detected before.

```
Comparing ./1604(unfixed-cves)/w3af.old with ./1604(unfixed-cves)/w3af.new
1c1,107
< {}
---
> {
>     "CVE-2013-2099": {
...
>         "patches": [
>             {
>                 "package_name": "w3af",
>                 "release_patches": [
>                     {
>                         "release_name": "esm-apps/xenial",
>                         "status": "needed",
>                         "note": ""
>                     }
>                 ]
>             }
>         ],
```

# Checklist:

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES