### PR TITLE
fix(fetcher/redhatapi): mitigation type switch

### DIFF
--- a/fetcher/redhatapi.go
+++ b/fetcher/redhatapi.go
@@ -94,6 +94,23 @@ func RetrieveRedhatCveDetails(urls []string) (cves []models.RedhatCVEJSON, err e
 		default:
 			return nil, errors.New("Unknown package_state type")
 		}
+
+		switch cve.TempMitigation.(type) {
+		case string:
+			cve.Mitigation = cve.TempMitigation.(string)
+		case map[string]interface{}:
+			var m struct {
+				Mitigation models.RedhatCVEJSONMitigationObject `json:"mitigation"`
+			}
+			if err := json.Unmarshal(cveJSON, &m); err != nil {
+				return nil, xerrors.Errorf("unknown mitigation type err: %w", err)
+			}
+			cve.Mitigation = m.Mitigation.Value
+		case nil:
+		default:
+			return nil, errors.New("Unknown mitigation type")
+		}
+
 		cves = append(cves, cve)
 	}
 

--- a/models/redhat.go
+++ b/models/redhat.go
@@ -36,8 +36,9 @@ type RedhatCVEJSON struct {
 	Cwe                  string         `json:"cwe"`
 	Statement            string         `json:"statement"`
 	Acknowledgement      string         `json:"acknowledgement"`
-	Mitigation           string         `json:"mitigation"`
-	TempAffectedRelease  interface{}    `json:"affected_release"` // affected_release is array or object
+	TempMitigation       interface{}    `json:"mitigation"`
+	Mitigation           string
+	TempAffectedRelease  interface{} `json:"affected_release"` // affected_release is array or object
 	AffectedRelease      []RedhatAffectedRelease
 	TempPackageState     interface{} `json:"package_state"` // package_state is array or object
 	PackageState         []RedhatPackageState
@@ -66,6 +67,11 @@ type RedhatCVEJSONPackageStateArray struct {
 // RedhatCVEJSONPackageStateObject :
 type RedhatCVEJSONPackageStateObject struct {
 	PackageState RedhatPackageState `json:"package_state"`
+}
+
+type RedhatCVEJSONMitigationObject struct {
+	Value string `json:"value"`
+	Lang  string `json:"lang"`
 }
 
 // RedhatCVE :


### PR DESCRIPTION
# What did you implement:

Fixes #194 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ gost fetch redhatapi
INFO[06-13|15:21:42] Initialize Database 
INFO[06-13|15:21:42] Fetch the list of CVEs 
INFO[06-13|15:24:22] Fetched 28436 CVEs 
28436 / 28436 [-------------------------------------------------] 100.00% 20 p/s
Failed to fetch the CVE details. err: json: cannot unmarshal object into Go struct field RedhatCVEJSON.mitigation of type string
```

## after
```console
$ gost fetch redhatapi
INFO[06-14|00:39:48] Initialize Database 
INFO[06-14|00:39:48] Fetch the list of CVEs 
INFO[06-14|00:42:23] Fetched 28441 CVEs 
28441 / 28441 [-------------------------------------------------] 100.00% 17 p/s
INFO[06-14|01:09:36] Insert RedHat into DB                    db=sqlite3
INFO[06-14|01:09:36] Insert 28441 CVEs 
28441 / 28441 [-----------------------------------------------] 100.00% 4426 p/s

```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

