### PR TITLE
fix(fetcher/redhat): use vuln-list-redhat insted of vuln-list

### DIFF
--- a/fetcher/redhat.go
+++ b/fetcher/redhat.go
@@ -15,15 +15,15 @@ import (
 )
 
 const (
-	repoURL   = "https://github.com/aquasecurity/vuln-list.git"
-	redhatDir = "redhat"
+	redhatRepoURL = "https://github.com/aquasecurity/vuln-list-redhat.git"
+	redhatDir     = "api"
 )
 
 // FetchRedHatVulnList clones vuln-list and returns CVE JSONs
 func FetchRedHatVulnList() (entries []models.RedhatCVEJSON, err error) {
 	// Clone vuln-list repository
-	dir := filepath.Join(util.CacheDir(), "vuln-list")
-	updatedFiles, err := git.CloneOrPull(repoURL, dir, redhatDir)
+	dir := filepath.Join(util.CacheDir(), "vuln-list-redhat")
+	updatedFiles, err := git.CloneOrPull(redhatRepoURL, dir, redhatDir)
 	if err != nil {
 		return nil, xerrors.Errorf("error in vulnsrc clone or pull: %w", err)
 	}

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -15,14 +15,15 @@ import (
 )
 
 const (
-	ubuntuDir = "ubuntu"
+	ubuntuRepoURL = "https://github.com/aquasecurity/vuln-list.git"
+	ubuntuDir     = "ubuntu"
 )
 
 // FetchUbuntuVulnList clones vuln-list and returns CVE JSONs
 func FetchUbuntuVulnList() (entries []models.UbuntuCVEJSON, err error) {
 	// Clone vuln-list repository
 	dir := filepath.Join(util.CacheDir(), "vuln-list")
-	updatedFiles, err := git.CloneOrPull(repoURL, dir, ubuntuDir)
+	updatedFiles, err := git.CloneOrPull(ubuntuRepoURL, dir, ubuntuDir)
 	if err != nil {
 		return nil, xerrors.Errorf("error in vulnsrc clone or pull: %w", err)
 	}


### PR DESCRIPTION
# What did you implement:

Fixes #93 

vuln-list was temporarily inaccessible.
And vuln-list, which has regained access, no longer has the redhat directory that was there before, and has moved to the api directory of the vuln-list-redhat repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ gost fetch redhat
gost fetch redhat
INFO[07-27|16:46:09] Initialize Database 
INFO[07-27|16:46:11] Insert RedHat into DB                    db=sqlite3
INFO[07-27|16:46:11] Insert 0 CVEs 
0 [___________________________________________________________________] ?% ? p/s

```

## after
```console
$ gost fetch redhat
INFO[07-27|16:48:34] Initialize Database 
INFO[07-27|16:48:35] Insert RedHat into DB                    db=sqlite3
INFO[07-27|16:48:35] Insert 28699 CVEs 
28699 / 28699 [-----------------------------------------------] 100.00% 4383 p/s

```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

