### PR TITLE
fix(fetcher/ubuntu): temporarily use vuln-list-reserve

### DIFF
--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -15,14 +15,14 @@ import (
 )
 
 const (
-	ubuntuRepoURL = "https://github.com/aquasecurity/vuln-list.git"
+	ubuntuRepoURL = "https://github.com/aquasecurity/vuln-list-reserve.git"
 	ubuntuDir     = "ubuntu"
 )
 
 // FetchUbuntuVulnList clones vuln-list and returns CVE JSONs
 func FetchUbuntuVulnList() (entries []models.UbuntuCVEJSON, err error) {
 	// Clone vuln-list repository
-	dir := filepath.Join(util.CacheDir(), "vuln-list")
+	dir := filepath.Join(util.CacheDir(), "vuln-list-reserve")
 	updatedFiles, err := git.CloneOrPull(ubuntuRepoURL, dir, ubuntuDir)
 	if err != nil {
 		return nil, xerrors.Errorf("error in vulnsrc clone or pull: %w", err)


### PR DESCRIPTION
# What did you implement:

vuln-list repository has stopped updating as follows.

```console
$ git clone --depth 1 https://github.com/aquasecurity/vuln-list.git
Cloning into 'vuln-list'...
remote: Enumerating objects: 390383, done.
remote: Counting objects: 100% (390383/390383), done.
remote: Compressing objects: 100% (103538/103538), done.
remote: Total 390383 (delta 317891), reused 345568 (delta 279851), pack-reused 0
Receiving objects: 100% (390383/390383), 294.43 MiB | 10.93 MiB/s, done.
Resolving deltas: 100% (317891/317891), done.
Updating files: 100% (370720/370720), done.

$ cd vuln-list

$ git log
commit dbd91fb18af8d182f3828360f3328a6e92d3bd0e (grafted, HEAD -> main, origin/main, origin/HEAD)
Author: GitHub Action <action@github.com>
Date:   Thu Jul 20 12:49:23 2023 +0000

    OSV Database
```

Currently, they are updating the vuln-list-reserve repository instead of the vuln-list repository.
https://github.com/aquasecurity/vuln-list-update/blob/64d02d0d46b6607b8fa3b705df9154f95b96ba34/.github/workflows/update.yml#L26

So we also use the vuln-list-reserve repository temporarily.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## before
```console
$ gost fetch ubuntu
INFO[07-31|11:03:02] Initialize Database 
INFO[07-31|11:03:02] Fetched                                  CVEs=44615
INFO[07-31|11:03:02] Insert Ubuntu into DB                    db=sqlite3
44615 / 44615 [------------------------------------------------] 100.00% 930 p/s

$ sqlite3 gost.sqlite3 "SELECT * FROM ubuntu_cves WHERE candidate = 'CVE-2023-32629';"
```

## after
```console
$ gost fetch ubuntu
INFO[07-31|11:04:26] Initialize Database 
INFO[07-31|11:04:26] Fetched                                  CVEs=44624
INFO[07-31|11:04:26] Insert Ubuntu into DB                    db=sqlite3
44624 / 44624 [------------------------------------------------] 100.00% 984 p/s

$ sqlite3 gost.sqlite3 "SELECT * FROM ubuntu_cves WHERE candidate = 'CVE-2023-32629';"
44354|2023-06-06 00:00:00+00:00|2023-06-06 00:00:00+00:00|CVE-2023-32629|2023-07-26 02:15:00+00:00|Local privilege escalation vulnerability in Ubuntu Kernels overlayfs ovl_copy_up_meta_inode_data skip permission checks when calling ovl_do_setxattr on Ubuntu kernels|Shir Tamari and Sagi Tzadik discovered that the OverlayFS implementation in the Ubuntu Linux kernel did not properly perform permission checks in certain situations. A local attacker could possibly use this to gain elevated privileges.|high|Shir Tamari and Sagi Tzadik|cascardo
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

