### PR TITLE
feat(fetcher/ubuntu): use vuln-list instead of vuln-list-reserve

### DIFF
--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -15,14 +15,14 @@ import (
 )
 
 const (
-	ubuntuRepoURL = "https://github.com/aquasecurity/vuln-list-reserve.git"
+	ubuntuRepoURL = "https://github.com/aquasecurity/vuln-list.git"
 	ubuntuDir     = "ubuntu"
 )
 
 // FetchUbuntuVulnList clones vuln-list and returns CVE JSONs
 func FetchUbuntuVulnList() (entries []models.UbuntuCVEJSON, err error) {
 	// Clone vuln-list repository
-	dir := filepath.Join(util.CacheDir(), "vuln-list-reserve")
+	dir := filepath.Join(util.CacheDir(), "vuln-list")
 	updatedFiles, err := git.CloneOrPull(ubuntuRepoURL, dir, ubuntuDir)
 	if err != nil {
 		return nil, xerrors.Errorf("error in vulnsrc clone or pull: %w", err)


### PR DESCRIPTION
# What did you implement:

vuln-list(https://github.com/aquasecurity/vuln-list) has been revived, and vuln-list-reserve(https://github.com/aquasecurity/vuln-list-reserve) has stopped updating.
Therefore, change the repository used for ubuntu fetch from vuln-list-reserve to vuln-list.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ gost fetch ubuntu
INFO[09-06|15:24:21] Initialize Database 
INFO[09-06|15:24:21] Fetched                                  CVEs=44821
INFO[09-06|15:24:21] Insert Ubuntu into DB                    db=sqlite3
44821 / 44821 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 532 p/s

```

## after
```console
$ gost fetch ubuntu
INFO[09-06|15:17:20] Initialize Database 
INFO[09-06|15:17:20] Fetched                                  CVEs=45122
INFO[09-06|15:17:20] Insert Ubuntu into DB                    db=sqlite3
45122 / 45122 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 681 p/s

```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

