### PR TITLE
fix(models/debian): remove gorm tag for mysql

### DIFF
--- a/models/debian.go
+++ b/models/debian.go
@@ -29,7 +29,7 @@ type DebianCVE struct {
 	ID          int64  `json:"-"`
 	CveID       string `gorm:"index:idx_debian_cves_cveid;type:varchar(255);"`
 	Scope       string `gorm:"type:varchar(255)"`
-	Description string `gorm:"type:text"`
+	Description string
 	Package     []DebianPackage
 }
 


### PR DESCRIPTION
# What did you implement:

When referring to the Description in Trivy, there are some that are very large in size. In that case, the text type will not fit, and you will need to use longtext. Therefore, remove the gorm tag.

```console
$ bbolt get trivy.db vulnerability CVE-2023-5090 | jq .Description > CVE-2023-5090_Description.txt
```
[CVE-2023-5090_Description.txt](https://github.com/vulsio/gost/files/13065340/CVE-2023-5090_Description.txt)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ docker run --rm --name mysql -d -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=test -p 3306:3306 mysql
$ gost fetch debian --dbtype mysql --dbpath "root:password@tcp(127.0.0.1:3306)/test?parseTime=true"
INFO[10-23|10:30:54] Initialize Database 
INFO[10-23|10:30:57] Fetched all CVEs from Debian 
INFO[10-23|10:31:12] Fetched                                  CVEs=35509
INFO[10-23|10:31:12] Insert Debian CVEs into DB               db=mysql
14638 / 35509 [------------------------------------------------------------------------->_________________________________________________________________________________________________________] 41.22% 1000 p/sFailed to insert. dbpath: root:password@tcp(127.0.0.1:3306)/test?parseTime=true, err: Failed to insert Debian CVE data. err: Failed to insert. err: Error 1406 (22001): Data too long for column 'description' at row 1
$ mysql -h 127.0.0.1 -P 3306 -u root -ppassword
mysql> USE test;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> SHOW COLUMNS FROM debian_cves;
+-------------+--------------+------+-----+---------+----------------+
| Field       | Type         | Null | Key | Default | Extra          |
+-------------+--------------+------+-----+---------+----------------+
| id          | bigint       | NO   | PRI | NULL    | auto_increment |
| cve_id      | varchar(255) | YES  | MUL | NULL    |                |
| scope       | varchar(255) | YES  |     | NULL    |                |
| description | text         | YES  |     | NULL    |                |
+-------------+--------------+------+-----+---------+----------------+
4 rows in set (0.00 sec)

```

## after
```console
$ docker run --rm --name mysql -d -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=test -p 3306:3306 mysql
$ gost fetch debian --dbtype mysql --dbpath "root:password@tcp(127.0.0.1:3306)/test?parseTime=true"
INFO[10-23|10:35:58] Initialize Database 
INFO[10-23|10:36:02] Fetched all CVEs from Debian 
INFO[10-23|10:36:06] Fetched                                  CVEs=35509
INFO[10-23|10:36:06] Insert Debian CVEs into DB               db=mysql
35509 / 35509 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 1873 p/s
$ mysql -h 127.0.0.1 -P 3306 -u root -ppassword
mysql> USE test;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> SHOW COLUMNS FROM debian_cves;
+-------------+--------------+------+-----+---------+----------------+
| Field       | Type         | Null | Key | Default | Extra          |
+-------------+--------------+------+-----+---------+----------------+
| id          | bigint       | NO   | PRI | NULL    | auto_increment |
| cve_id      | varchar(255) | YES  | MUL | NULL    |                |
| scope       | varchar(255) | YES  |     | NULL    |                |
| description | longtext     | YES  |     | NULL    |                |
+-------------+--------------+------+-----+---------+----------------+
4 rows in set (0.01 sec)
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference


