### PR TITLE
fix: parse the git output

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -20,8 +20,15 @@ func getGitVersion() (string, error) {
 	if err != nil {
 		return "", xerrors.Errorf("error in git --version: %w", err)
 	}
-	version := strings.TrimSpace(strings.TrimPrefix(output, "git version"))
-	return version, nil
+
+	// Parse the output of "git --version"
+	// e.g. "git version 2.34.1"
+	//      "git version 2.39.3 (Apple Git-145)"
+	ss := strings.Fields(output)
+	if len(ss) < 3 {
+		return "", xerrors.Errorf("unexpected output")
+	}
+	return ss[2], nil
 }
 
 // CloneOrPull clone/pull aquasecurity/vuln-list


### PR DESCRIPTION
# What did you implement:
gost doesn't work on macOS as git returns an unexpected output.

```
$ gost fetch ubuntu --dbtype redis --dbpath redis://localhost
Failed to initialize vulnerability DB . err: error in vulnsrc clone or pull: failed to clone repository: error in version.NewVersion(2.39.3 (Apple Git-145)): Malformed version: 2.39.3 (Apple Git-145)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run gost in macOS.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
