### PR TITLE
fix(models/microsoft): fill default time to PublishDate, LastUpdateDate

### DIFF
--- a/models/microsoft.go
+++ b/models/microsoft.go
@@ -132,16 +132,18 @@ func ConvertMicrosoft(vulns []MicrosoftVulnerability, supercedences []MicrosoftS
 	cves := []MicrosoftCVE{}
 	for _, v := range vulns {
 		cve := MicrosoftCVE{
-			CveID:         v.CveID,
-			Title:         v.Title,
-			Description:   v.Description,
-			FAQ:           strings.Join(v.FAQs, "\n"),
-			Tag:           v.Tag,
-			CNA:           v.CNA,
-			ExploitStatus: v.ExploitStatus,
-			Mitigation:    v.Mitigation,
-			Workaround:    v.Workaround,
-			URL:           v.URL,
+			CveID:          v.CveID,
+			Title:          v.Title,
+			Description:    v.Description,
+			FAQ:            strings.Join(v.FAQs, "\n"),
+			Tag:            v.Tag,
+			CNA:            v.CNA,
+			ExploitStatus:  v.ExploitStatus,
+			Mitigation:     v.Mitigation,
+			Workaround:     v.Workaround,
+			URL:            v.URL,
+			PublishDate:    time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			LastUpdateDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
 		}
 
 		for _, p := range v.Products {


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:
As shown below, if there are no revisions, the PublishDate and LastUpdateDate will be 0000-00-00. 
```console
$ curl -s https://raw.githubusercontent.com/vulsio/windows-vuln-feed/main/dist/vulnerability/vulnerability.json.gz | zcat | jq -r '.[] | select(.CVEID == "CVE-2022-28737")'
{
  "CVEID": "CVE-2022-28737",
  "Tag": "Mariner",
  "CNA": "security@ubuntu.com",
  "ExploitStatus": "DOS:N/A",
  "Products": null,
  "URL": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-28737"
}
```
If you are using MySQL, this may fail.
https://github.com/vulsio/gost/actions/runs/10783604555/job/29905826463

In such cases, change them to use 1000-01-01 instead of 0000-00-00.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
test by Fetch CI

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

