### PR TITLE
refactor(fetcher/redhat): use iterator

### DIFF
--- a/cmd/redhat.go
+++ b/cmd/redhat.go
@@ -40,11 +40,6 @@ func fetchRedHat(_ *cobra.Command, _ []string) (err error) {
 	}
 	defer os.RemoveAll(filepath.Join(util.CacheDir(), "vuln-list-redhat"))
 
-	cves, err := models.ConvertRedhat(cveJSONs)
-	if err != nil {
-		return xerrors.Errorf("Failed to convert RedhatCVE. err: %w", err)
-	}
-
 	log15.Info("Initialize Database")
 	driver, err := db.NewDB(viper.GetString("dbtype"), viper.GetString("dbpath"), viper.GetBool("debug-sql"), db.Option{})
 	if err != nil {
@@ -67,7 +62,7 @@ func fetchRedHat(_ *cobra.Command, _ []string) (err error) {
 	}
 
 	log15.Info("Insert RedHat into DB", "db", driver.Name())
-	if err := driver.InsertRedhat(cves); err != nil {
+	if err := driver.InsertRedhat(models.ConvertRedhat(cveJSONs)); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 

--- a/cmd/ubuntu.go
+++ b/cmd/ubuntu.go
@@ -40,8 +40,6 @@ func fetchUbuntu(_ *cobra.Command, _ []string) (err error) {
 	}
 	defer os.RemoveAll(filepath.Join(util.CacheDir(), "vuln-list"))
 
-	cves := models.ConvertUbuntu(cveJSONs)
-
 	log15.Info("Initialize Database")
 	driver, err := db.NewDB(viper.GetString("dbtype"), viper.GetString("dbpath"), viper.GetBool("debug-sql"), db.Option{})
 	if err != nil {
@@ -64,7 +62,7 @@ func fetchUbuntu(_ *cobra.Command, _ []string) (err error) {
 	}
 
 	log15.Info("Insert Ubuntu into DB", "db", driver.Name())
-	if err := driver.InsertUbuntu(cves); err != nil {
+	if err := driver.InsertUbuntu(models.ConvertUbuntu(cveJSONs)); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 

--- a/db/db.go
+++ b/db/db.go
@@ -47,7 +47,7 @@ type DB interface {
 	GetUnfixedAdvsArch(string) (map[string]models.ArchADV, error)
 	GetAdvisoriesArch() (map[string][]string, error)
 
-	InsertRedhat([]models.RedhatCVE) error
+	InsertRedhat(iter.Seq2[models.RedhatCVE, error]) error
 	InsertDebian([]models.DebianCVE) error
 	InsertUbuntu(iter.Seq2[models.UbuntuCVE, error]) error
 	InsertMicrosoft([]models.MicrosoftCVE, []models.MicrosoftKBRelation) error

--- a/db/ubuntu.go
+++ b/db/ubuntu.go
@@ -117,7 +117,7 @@ func (r *RDBDriver) deleteAndInsertUbuntu(cves iter.Seq2[models.UbuntuCVE, error
 
 	for chunk, err := range util.Chunk(cves, batchSize) {
 		if err != nil {
-			return xerrors.Errorf("failed to insert Ubuntu CVE data. err: %w", err)
+			return xerrors.Errorf("Failed to chunk Ubuntu CVE data. err: %w", err)
 		}
 
 		if err = tx.Create(chunk).Error; err != nil {

--- a/models/ubuntu.go
+++ b/models/ubuntu.go
@@ -107,9 +107,13 @@ type UbuntuUpstreamLink struct {
 func ConvertUbuntu(cveJSONs iter.Seq2[UbuntuCVEJSON, error]) iter.Seq2[UbuntuCVE, error] {
 	return func(yield func(UbuntuCVE, error) bool) {
 		for cve, err := range cveJSONs {
-			if err != nil && !yield(UbuntuCVE{}, err) {
-				return
+			if err != nil {
+				if !yield(UbuntuCVE{}, err) {
+					return
+				}
+				continue
 			}
+
 			if strings.Contains(cve.Description, "** REJECT **") {
 				continue
 			}

--- a/util/util.go
+++ b/util/util.go
@@ -228,8 +228,11 @@ func Chunk[T any](s iter.Seq2[T, error], n int) iter.Seq2[[]T, error] {
 
 		chunk := make([]T, 0, n)
 		for t, err := range s {
-			if err != nil && !yield(nil, err) {
-				return
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
 			}
 			chunk = append(chunk, t)
 			if len(chunk) != n {


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

use iterator in fetching redhat

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## before
```console
$ /usr/bin/time -v ./gost fetch redhat
INFO[04-28|11:33:34] Initialize Database 
INFO[04-28|11:33:34] Insert RedHat into DB                    db=sqlite3
INFO[04-28|11:33:34] Insert 37983 CVEs 
37983 / 37983 [-------------------------------------------------------------------------------------] 100.00% 2270 p/s
	Command being timed: "./gost fetch redhat"
	User time (seconds): 54.15
	System time (seconds): 13.87
	Percent of CPU this job got: 22%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 5:06.05
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1021852
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 707643
	Voluntary context switches: 786633
	Involuntary context switches: 10212
	Swaps: 0
	File system inputs: 0
	File system outputs: 1106872
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

## after
```console
$ /usr/bin/time -v ./gost fetch redhat
INFO[04-28|11:27:41] Initialize Database 
INFO[04-28|11:27:41] Insert RedHat into DB                    db=sqlite3
[================>   ] 37983 files processed. (1823 p/s)                                                              
	Command being timed: "./gost fetch redhat"
	User time (seconds): 57.29
	System time (seconds): 14.16
	Percent of CPU this job got: 23%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 5:05.95
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 51304
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 512658
	Voluntary context switches: 888403
	Involuntary context switches: 10826
	Swaps: 0
	File system inputs: 12376
	File system outputs: 811240
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

