### PR TITLE
feat(db,fetcher/debian): Add Debian 14 (forky) and 15 (duke)

### DIFF
--- a/db/debian.go
+++ b/db/debian.go
@@ -110,6 +110,8 @@ var debVerCodename = map[string]string{
 	"11": "bullseye",
 	"12": "bookworm",
 	"13": "trixie",
+	"14": "forky",
+	"15": "duke",
 }
 
 // GetUnfixedCvesDebian gets the CVEs related to debian_release.status = 'open', major, pkgName.

--- a/fetcher/debian.go
+++ b/fetcher/debian.go
@@ -196,6 +196,8 @@ func walkDB(dbpath string) (models.DebianJSON, error) {
 		"11": "bullseye",
 		"12": "bookworm",
 		"13": "trixie",
+		"14": "forky",
+		"15": "duke",
 	}
 
 	cves := models.DebianJSON{}


### PR DESCRIPTION
# What did you implement:

This pull request add support for debian 14, fetcher is failling since debian 13 release this weekend (09th August 2025) and the addition of debian 14 (Forky) which is not supported by gost yet.

It failed with the following error:

```
/gost fetch  debian
`INFO[08-11|11:32:33] Initialize Database 
INFO[08-11|11:32:33] Fetched all CVEs from Debian 
Failed to fetch CVE details from Trivy-DB. err: Failed to view db. err: Failed to foreach. err: not found debian major version. actual: 14

```
Fixes #332 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

by fetch CI (https://github.com/vulsio/gost/actions/runs/16947850895/job/48033312301?pr=333)

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

