### PR TITLE
fix(models/redhat): split reference with a newline

### DIFF
--- a/models/redhat.go
+++ b/models/redhat.go
@@ -234,11 +234,13 @@ func ConvertRedhat(cveJSONs iter.Seq2[RedhatCVEJSON, error]) iter.Seq2[RedhatCVE
 					return details
 				}(),
 				References: func() []RedhatReference {
-					references := make([]RedhatReference, 0, len(cve.References))
+					var rs []RedhatReference
 					for _, r := range cve.References {
-						references = append(references, RedhatReference{Reference: util.TrimSpaceNewline(r)})
+						for l := range strings.Lines(r) {
+							rs = append(rs, RedhatReference{Reference: util.TrimSpaceNewline(l)})
+						}
 					}
-					return references
+					return rs
 				}(),
 			}, nil) {
 				return


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

It seems that line breaks have been included in references from before. 
https://github.com/aquasecurity/vuln-list-redhat/blob/e680b6fad101e24090d5bed970f4176916a56f0f/api/2025/CVE-2025-47907.json

They will now be split appropriately using line breaks.

https://go.dev/play/p/TphzEksSyBZ

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ gost fetch redhat
$ gost server &
$ curl -s http://127.0.0.1:1325/redhat/cves/CVE-2025-47907 | jq .References
[
  {
    "Reference": "https://www.cve.org/CVERecord?id=CVE-2025-47907\nhttps://nvd.nist.gov/vuln/detail/CVE-2025-47907\nhttps://go.dev/cl/693735\nhttps://go.dev/issue/74831\nhttps://groups.google.com/g/golang-announce/c/x5MKroML2yM\nhttps://pkg.go.dev/vuln/GO-2025-3849"
  }
]
```

## after
```console
$ gost fetch redhat
$ gost server &
$ curl -s http://127.0.0.1:1325/redhat/cves/CVE-2025-47907 | jq .References
[
  {
    "Reference": "https://www.cve.org/CVERecord?id=CVE-2025-47907"
  },
  {
    "Reference": "https://nvd.nist.gov/vuln/detail/CVE-2025-47907"
  },
  {
    "Reference": "https://go.dev/cl/693735"
  },
  {
    "Reference": "https://go.dev/issue/74831"
  },
  {
    "Reference": "https://groups.google.com/g/golang-announce/c/x5MKroML2yM"
  },
  {
    "Reference": "https://pkg.go.dev/vuln/GO-2025-3849"
  }
]
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
