### PR TITLE
fix(ci/release): grant contents:write to goreleaser job

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,9 +5,13 @@ on:
     tags:
       - '*'
 
+permissions: {}
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       -
         name: Checkout


### PR DESCRIPTION
## Summary
- The default `GITHUB_TOKEN` permissions are read-only in many repo/org configurations, which makes the goreleaser action fail at the `scm releases` step with `403 Resource not accessible by integration` when trying to PATCH the GitHub Release. The sibling repo [vulsio/go-cpe-dictionary](https://github.com/vulsio/go-cpe-dictionary/actions/runs/25646918221) hit exactly this on its `v0.9.5` tag push.
- Deny everything at the workflow level (`permissions: {}`) and grant `contents: write` only to the `goreleaser` job, following the least-privilege principle. Mirrors vulsio/go-cpe-dictionary#275.

## Test plan
- [ ] Push a release tag and confirm the GitHub Release is published successfully by goreleaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)